### PR TITLE
Adding type info to Idl accounts array

### DIFF
--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -452,6 +452,7 @@ fn idl_accounts(
                 let accounts = idl_accounts(accs_strct, global_accs);
                 IdlAccountItem::IdlAccounts(IdlAccounts {
                     name: comp_f.ident.to_string().to_mixed_case(),
+                    symbol: comp_f.symbol.to_string().to_mixed_case(),
                     accounts,
                 })
             }

--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -233,7 +233,7 @@ pub fn parse(filename: impl AsRef<Path>) -> Result<Option<Idl>> {
         },
         errors: error_codes,
         metadata: None,
-        context: context,
+        context,
     }))
 }
 

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -20,6 +20,7 @@ pub struct Idl {
     pub errors: Option<Vec<IdlErrorCode>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub metadata: Option<JsonValue>,
+    pub context: IdlContext,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -29,10 +30,23 @@ pub struct IdlState {
     pub methods: Vec<IdlInstruction>,
 }
 
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IdlContext {
+    pub accounts: Vec<IdlContextAccounts>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IdlContextAccounts {
+    pub symbol: String,
+    pub accounts: Vec<IdlAccountItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct IdlInstruction {
     pub name: String,
-    pub accounts: Vec<IdlAccountItem>,
+    pub accounts_symbol: String,
     pub args: Vec<IdlField>,
 }
 
@@ -41,7 +55,6 @@ pub struct IdlInstruction {
 pub struct IdlAccounts {
     pub name: String,
     pub symbol: String,
-    pub accounts: Vec<IdlAccountItem>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -40,6 +40,7 @@ pub struct IdlInstruction {
 #[serde(rename_all = "camelCase")]
 pub struct IdlAccounts {
     pub name: String,
+    pub symbol: String,
     pub accounts: Vec<IdlAccountItem>,
 }
 


### PR DESCRIPTION
Changed the IDL structure to separate the Account metas from the Instructions.
The goal of this change is to allow re-usage of account structures when generating client code.
As a side effect, the IDL will be smaller if there are multiple Instructions re-using the any account structures.

Parsing the IDL for the `swap` example program we get the following changes:
- from
```
  "instructions": [
    {
      "name": "swap",
      "accounts": [
        {
          "name": "market",
          "accounts": [
            {
              "name": "market",
              "isMut": true,
              "isSigner": false
            },
   

```
- to
```
  "instructions": [
    {
      "name": "swap",
      "accountsSymbol": "Swap",
      "args": [
          ....
      ]
    },


   ........................................
  "context": {
    "accounts": [
      {
        "symbol": "swap",
        "accounts": [
          {
            "name": "market",
            "symbol": "marketAccounts"
          },
          {
            "name": "authority",
            "isMut": false,
            "isSigner": true
          },

      ..........................

          ]
      },
      {
        "symbol": "marketAccounts",
        "accounts": [
          {
            "name": "market",
            "isMut": true,
            "isSigner": false
          },
          {

      .............................

```

For this specific example, the IDL size went down from 8008 to 5471 bytes.