### PR TITLE
signVerify when legitimate signers, replaceRecentBlockhash when not signing to avoid AlreadyProcessed error

### DIFF
--- a/tests/events/tests/events.js
+++ b/tests/events/tests/events.js
@@ -22,6 +22,15 @@ describe("events", () => {
     assert.ok(event.label === "hello");
   });
 
+  it("Events through simulation", async () => {
+    const simulateResponse = await program.simulate.initialize();
+
+    const events = simulateResponse.events;
+    assert.ok(events.length === 1);
+    assert.ok(events[0].data.data.toNumber() === 5);
+    assert.ok(events[0].data.label === "hello");
+  })
+
   it("Multiple events", async () => {
     // Sleep so we don't get this transaction has already been processed.
     await sleep(2000);

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -271,9 +271,15 @@ async function simulateTransaction(
   let config: any = { encoding: "base64", commitment };
 
   // Sign only when there are signatures, ignoring the case where only the fee payer is present and signature is null
-  if (transaction.signatures.length > 0 && !(transaction.signatures.length === 1 && transaction.signatures[0].signature === null)) {
-      // @ts-ignore
-      transaction.recentBlockhash = await connection._recentBlockhash(
+  if (
+    transaction.signatures.length > 0 &&
+    !(
+      transaction.signatures.length === 1 &&
+      transaction.signatures[0].signature === null
+    )
+  ) {
+    // @ts-ignore
+    transaction.recentBlockhash = await connection._recentBlockhash(
       // @ts-ignore
       connection._disableBlockhashCaching
     );


### PR DESCRIPTION
Two links that can explain a bit why I did it like that. I don't think it is perfect but at least for the general case, it should do.
People who want to simulate with full signature should just do a preflight in most cases.

https://github.com/solana-labs/solana-web3.js/blob/e89abb0969d138e83fabd18330f7b33b8d88573b/src/connection.ts#L3432-L3500
https://docs.solana.com/developing/clients/jsonrpc-api#simulatetransaction