### PR TITLE
Update dex cpis and update dex version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "serum_dex"
 version = "0.4.0"
-source = "git+https://github.com/project-serum/serum-dex?rev=1be91f2#1be91f2863d8ecede32daaae7e768034e24bbc79"
+source = "git+https://github.com/project-serum/serum-dex?rev=0c730d6#0c730d678fd5ec0b07b17465e310a7f2a81b6681"
 dependencies = [
  "arrayref",
  "bincode",

--- a/spl/Cargo.toml
+++ b/spl/Cargo.toml
@@ -12,7 +12,7 @@ devnet = []
 [dependencies]
 anchor-lang = { path = "../lang", version = "0.17.0", features = ["derive"] }
 lazy_static = "1.4.0"
-serum_dex = { git = "https://github.com/project-serum/serum-dex", rev = "1be91f2", version = "0.4.0", features = ["no-entrypoint"] }
+serum_dex = { git = "https://github.com/project-serum/serum-dex", rev = "0c730d6", features = ["no-entrypoint"] }
 solana-program = "=1.7.11"
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "1.0.3", features = ["no-entrypoint"] }

--- a/spl/src/dex/cpi.rs
+++ b/spl/src/dex/cpi.rs
@@ -225,7 +225,7 @@ pub fn consume_events<'info>(
     limit: u16,
 ) -> ProgramResult {
     let mut open_orders_accounts = Vec::new();
-    for acc in &mut ctx.remaining_accounts.iter() {
+    for acc in ctx.remaining_accounts.iter() {
         open_orders_accounts.push(acc.key);
     }
 
@@ -253,7 +253,7 @@ pub fn consume_events_permissioned<'info>(
     limit: u16,
 ) -> ProgramResult {
     let mut open_orders_accounts = Vec::new();
-    for acc in &mut ctx.remaining_accounts.iter() {
+    for acc in ctx.remaining_accounts.iter() {
         open_orders_accounts.push(acc.key);
     }
 


### PR DESCRIPTION
Add new instructions to anchor spl dex
- `Prune`
- `ConsumeEvents`
- `ConsumeEventsPermissioned`

`ConsumeEventsPermissioned` is actually blocked until these PRs are merged as it's broken on serum's main branch. Awaiting:
- https://github.com/project-serum/serum-dex/pull/180
- https://github.com/project-serum/serum-dex/pull/178