### PR TITLE
Added error parameter to EventCallback type in event.ts, removed printing errors to stderr

### DIFF
--- a/ts/src/program/event.ts
+++ b/ts/src/program/event.ts
@@ -20,7 +20,7 @@ export type EventData<T extends IdlEventField, Defined> = {
   [N in T["name"]]: DecodeType<(T & { name: N })["type"], Defined>;
 };
 
-type EventCallback = (event: any, slot: number) => void;
+type EventCallback = (event: any, slot: number, err: any) => void;
 
 export class EventManager {
   /**
@@ -69,7 +69,7 @@ export class EventManager {
 
   public addEventListener(
     eventName: string,
-    callback: (event: any, slot: number) => void
+    callback: (event: any, slot: number, err: any) => void
   ): number {
     let listener = this._listenerIdCount;
     this._listenerIdCount += 1;
@@ -94,10 +94,6 @@ export class EventManager {
     this._onLogsSubscriptionId = this._provider!.connection.onLogs(
       this._programId,
       (logs, ctx) => {
-        if (logs.err) {
-          console.error(logs);
-          return;
-        }
         this._eventParser.parseLogs(logs.logs, (event) => {
           const allListeners = this._eventListeners.get(event.name);
           if (allListeners) {
@@ -105,7 +101,7 @@ export class EventManager {
               const listenerCb = this._eventCallbacks.get(listener);
               if (listenerCb) {
                 const [, callback] = listenerCb;
-                callback(event.data, ctx.slot);
+                callback(event.data, ctx.slot, logs.err);
               }
             });
           }


### PR DESCRIPTION
Attempt to fix #898 

> We should add an extra parameter in the callback to pass back the error

So here is my approach: I removed the whole [`if (logs.err)`](https://github.com/project-serum/anchor/blob/27de2a6ab4b650fcab360152db5a685ea1be3ce7/ts/src/program/event.ts#L97) block, then added an argument to the callback like this:
![image](https://user-images.githubusercontent.com/43410858/138022202-bd207580-7f7e-4d70-8fa9-40bc7e500731.png)
(I highlighted the argument I added)

And also added the `err` parameter to `EventCallback` type:
![image](https://user-images.githubusercontent.com/43410858/138022377-b857f817-7e07-4734-9b26-e951b6ed7663.png)

Let me know if this approach works, or if there is anything I ought to change.