### PR TITLE
Add support to close cpi accounts, such as TokenAccount

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -109,6 +109,7 @@ pub fn account(
                         crate::ID
                     }
                 }
+                impl #impl_gen anchor_lang::Ours for #account_name #type_gen #where_clause { }
             }
         } else {
             quote! {}

--- a/lang/src/boxed.rs
+++ b/lang/src/boxed.rs
@@ -35,7 +35,7 @@ impl<T: ToAccountMetas> ToAccountMetas for Box<T> {
 }
 
 impl<'info, T: AccountsClose<'info>> AccountsClose<'info> for Box<T> {
-    fn close(&self, sol_destination: AccountInfo<'info>) -> ProgramResult {
-        T::close(self, sol_destination)
+    fn close(&self, owner_program: Option<AccountInfo<'info>>, sol_destination: AccountInfo<'info>) -> ProgramResult {
+        T::close(self, owner_program, sol_destination)
     }
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -122,10 +122,15 @@ pub trait AccountsExit<'info>: ToAccountMetas + ToAccountInfos<'info> {
     fn exit(&self, program_id: &Pubkey) -> ProgramResult;
 }
 
-/// The close procedure to initiate garabage collection of an account, allowing
-/// one to retrieve the rent exemption.
+/// The close procedure dispatcher
 pub trait AccountsClose<'info>: ToAccountInfos<'info> {
-    fn close(&self, sol_destination: AccountInfo<'info>) -> ProgramResult;
+    fn close(&self, owner_program: Option<AccountInfo<'info>>, sol_destination: AccountInfo<'info>) -> ProgramResult;
+}
+
+/// The implementation of the close procedure to initiate garabage collection of an account
+/// allowing one to retrieve the rent exemption.
+pub trait AccountClose<'info> {
+    fn close(program: AccountInfo<'info>, account: AccountInfo<'info>, sol_destination: AccountInfo<'info>) -> ProgramResult;
 }
 
 /// Transformation to
@@ -225,6 +230,15 @@ pub trait Bump {
 /// Defines an address expected to own an account.
 pub trait Owner {
     fn owner() -> Pubkey;
+}
+
+/// Defines an account as owned by the current program.
+pub trait Ours {}
+
+impl<'info, T: Ours> AccountClose<'info> for T {
+    fn close(_program: AccountInfo<'info>, account: AccountInfo<'info>, sol_destination: AccountInfo<'info>) -> ProgramResult {
+        crate::common::close(account, sol_destination)
+    }
 }
 
 /// Defines the id of a program.

--- a/lang/src/loader.rs
+++ b/lang/src/loader.rs
@@ -157,7 +157,7 @@ impl<'info, T: ZeroCopy> AccountsExit<'info> for Loader<'info, T> {
 }
 
 impl<'info, T: ZeroCopy> AccountsClose<'info> for Loader<'info, T> {
-    fn close(&self, sol_destination: AccountInfo<'info>) -> ProgramResult {
+    fn close(&self, _owner_program: Option<AccountInfo<'info>>, sol_destination: AccountInfo<'info>) -> ProgramResult {
         crate::common::close(self.to_account_info(), sol_destination)
     }
 }

--- a/lang/src/loader_account.rs
+++ b/lang/src/loader_account.rs
@@ -157,7 +157,7 @@ impl<'info, T: ZeroCopy + Owner> AccountsExit<'info> for AccountLoader<'info, T>
 }
 
 impl<'info, T: ZeroCopy + Owner> AccountsClose<'info> for AccountLoader<'info, T> {
-    fn close(&self, sol_destination: AccountInfo<'info>) -> ProgramResult {
+    fn close(&self, _owner_program: Option<AccountInfo<'info>>, sol_destination: AccountInfo<'info>) -> ProgramResult {
         crate::common::close(self.to_account_info(), sol_destination)
     }
 }

--- a/lang/src/program_account.rs
+++ b/lang/src/program_account.rs
@@ -106,7 +106,7 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info
 impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsClose<'info>
     for ProgramAccount<'info, T>
 {
-    fn close(&self, sol_destination: AccountInfo<'info>) -> ProgramResult {
+    fn close(&self, _owner_program: Option<AccountInfo<'info>>, sol_destination: AccountInfo<'info>) -> ProgramResult {
         crate::common::close(self.to_account_info(), sol_destination)
     }
 }

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -163,13 +163,23 @@ pub fn generate_constraint_zeroed(f: &Field, _c: &ConstraintZeroed) -> proc_macr
     }
 }
 
-pub fn generate_constraint_close(f: &Field, c: &ConstraintClose) -> proc_macro2::TokenStream {
+pub fn generate_constraint_close(f: &Field, c: &ConstraintCloseGroup) -> proc_macro2::TokenStream {
     let field = &f.ident;
+    let owner_program_constraint = match &c.owner_program {
+        None => quote!{},
+        Some(owner_program) => quote!{
+            if #owner_program.to_account_info().key != #field.to_account_info().owner {
+                return Err(anchor_lang::__private::ErrorCode::ConstraintClose.into());
+            }
+        }
+    };
     let target = &c.sol_dest;
     quote! {
         if #field.to_account_info().key == #target.to_account_info().key {
             return Err(anchor_lang::__private::ErrorCode::ConstraintClose.into());
         }
+
+        #owner_program_constraint
     }
 }
 

--- a/lang/syn/src/codegen/accounts/exit.rs
+++ b/lang/syn/src/codegen/accounts/exit.rs
@@ -26,9 +26,20 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                 let ident = &f.ident;
                 if f.constraints.is_close() {
                     let close_target = &f.constraints.close.as_ref().unwrap().sol_dest;
+                    let close_owner_program = if let Some(program) = &f.constraints.close.as_ref().unwrap().owner_program {
+                        quote! {
+                            Some(self.#program.to_account_info())
+                        }
+                    } else {
+                        quote! {
+                            None
+                        }
+                    };
+
                     quote! {
                         anchor_lang::AccountsClose::close(
                             &self.#ident,
+                            #close_owner_program,
                             self.#close_target.to_account_info(),
                         )?;
                     }

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -511,7 +511,7 @@ pub struct ConstraintGroup {
     has_one: Vec<ConstraintHasOne>,
     literal: Vec<ConstraintLiteral>,
     raw: Vec<ConstraintRaw>,
-    close: Option<ConstraintClose>,
+    close: Option<ConstraintCloseGroup>,
     address: Option<ConstraintAddress>,
     associated_token: Option<ConstraintAssociatedToken>,
 }
@@ -553,7 +553,7 @@ pub enum Constraint {
     AssociatedToken(ConstraintAssociatedToken),
     Executable(ConstraintExecutable),
     State(ConstraintState),
-    Close(ConstraintClose),
+    Close(ConstraintCloseGroup),
     Address(ConstraintAddress),
 }
 
@@ -574,6 +574,7 @@ pub enum ConstraintToken {
     Executable(Context<ConstraintExecutable>),
     State(Context<ConstraintState>),
     Close(Context<ConstraintClose>),
+    Program(Context<ConstraintProgram>),
     Payer(Context<ConstraintPayer>),
     Space(Context<ConstraintSpace>),
     Address(Context<ConstraintAddress>),
@@ -698,8 +699,19 @@ pub enum InitKind {
 }
 
 #[derive(Debug, Clone)]
+pub struct ConstraintCloseGroup {
+    pub owner_program: Option<Ident>,
+    pub sol_dest: Ident,
+}
+
+#[derive(Debug, Clone)]
 pub struct ConstraintClose {
     pub sol_dest: Ident,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstraintProgram {
+    pub program: Ident,
 }
 
 #[derive(Debug, Clone)]

--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -4,7 +4,7 @@ use anchor_lang::solana_program::entrypoint::ProgramResult;
 use anchor_lang::solana_program::program_error::ProgramError;
 use anchor_lang::solana_program::program_pack::Pack;
 use anchor_lang::solana_program::pubkey::Pubkey;
-use anchor_lang::{Accounts, CpiContext};
+use anchor_lang::{Accounts, CpiContext, AccountClose};
 use std::io::Write;
 use std::ops::Deref;
 
@@ -318,6 +318,20 @@ pub struct TokenAccount(spl_token::state::Account);
 
 impl TokenAccount {
     pub const LEN: usize = spl_token::state::Account::LEN;
+}
+
+impl<'info> AccountClose<'info> for TokenAccount {
+    fn close(program: AccountInfo<'info>, account: AccountInfo<'info>, sol_destination: AccountInfo<'info>) -> ProgramResult {
+        let cpi_accounts = CloseAccount {
+            account: account,
+            destination: sol_destination.clone(),
+            authority: sol_destination.clone(),
+        };
+        let cpi_ctx = CpiContext::new(program, cpi_accounts);
+
+        close_account(cpi_ctx) // TODO Handle seeds
+    }
+
 }
 
 impl anchor_lang::AccountDeserialize for TokenAccount {

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -154,6 +154,14 @@ pub struct TestClose<'info> {
 }
 
 #[derive(Accounts)]
+pub struct TestTokenClose<'info> {
+    #[account(mut, close = sol_dest, program = token_program)]
+    pub token: Account<'info, TokenAccount>,
+    pub sol_dest: AccountInfo<'info>,
+    pub token_program: Program<'info, Token>
+}
+
+#[derive(Accounts)]
 pub struct TestU16<'info> {
     #[account(zero)]
     pub my_account: Account<'info, DataU16>,

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -85,6 +85,11 @@ pub mod misc {
         Ok(())
     }
 
+
+    pub fn test_token_close(_ctx: Context<TestTokenClose>) -> ProgramResult {
+        Ok(())
+    }
+
     pub fn test_instruction_constraint(
         _ctx: Context<TestInstructionConstraint>,
         _nonce: u8,

--- a/tests/misc/tests/misc.js
+++ b/tests/misc/tests/misc.js
@@ -252,6 +252,49 @@ describe("misc", () => {
     assert.ok(closedAccount === null);
   });
 
+  it("Can close a token account", async () => {
+    let mintA = await Token.createMint(
+      program.provider.connection,
+      program.provider.wallet.payer, // UintA
+      program.provider.wallet.publicKey,
+      null,
+      0,
+      TOKEN_PROGRAM_ID
+    );
+
+    let tokenAccount = await mintA.createAccount(program.provider.wallet.publicKey);
+
+    let beforeBalance = (
+      await program.provider.connection.getAccountInfo(
+        program.provider.wallet.publicKey
+      )
+    ).lamports;
+
+    // TODO Add mintA balance
+
+    await program.rpc.testTokenClose({
+      accounts: {
+        token: tokenAccount,
+        solDest: program.provider.wallet.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      },
+    });
+
+    let afterBalance = (
+      await program.provider.connection.getAccountInfo(
+        program.provider.wallet.publicKey
+      )
+    ).lamports;
+
+    // Retrieved rent exemption sol.
+    assert.ok(afterBalance > beforeBalance);
+
+    const closedAccount = await program.provider.connection.getAccountInfo(
+      tokenAccount
+    );
+    assert.ok(closedAccount === null);
+  });
+
   it("Can use instruction data in accounts constraints", async () => {
     // b"my-seed"
     const seed = Buffer.from([109, 121, 45, 115, 101, 101, 100]);


### PR DESCRIPTION
Fixes #851 

Changes:
- Implement a new trait `AccountClose` so CPI Accounts can implement a custom
  close function
- Add an `Ours` trait marker to be able to tag accounts generated by our program
  and provide a default `AccountClose` implementation
- Embed that `Ours` trait into the codegen for accounts
- Add unit test to be make sure we are able to close a TokenAccount

Shoutout to @cqfd for the assistance!