### PR TITLE
Adds account singleton fetching

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -152,6 +152,12 @@ pub trait ToAccountInfo<'info> {
     fn to_account_info(&self) -> AccountInfo<'info>;
 }
 
+/// Returns a singleton [AccountInfo] associated with the struct.
+pub trait HasSingletonAccount<'info, T> {
+    /// Returns a singleton [AccountInfo] associated with the struct.
+    fn get_account_info(&self) -> AccountInfo<'info>;
+}
+
 /// A data structure that can be serialized and stored into account storage,
 /// i.e. an
 /// [`AccountInfo`](../solana_program/account_info/struct.AccountInfo.html#structfield.data)'s

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -154,8 +154,8 @@ pub trait ToAccountInfo<'info> {
 
 /// Returns a singleton [AccountInfo] associated with the struct.
 pub trait HasSingletonAccount<'info, T> {
-    /// Returns a singleton [AccountInfo] associated with the struct.
-    fn get_account_info(&self) -> AccountInfo<'info>;
+    /// Returns the singleton [AccountInfo] instance associated with the struct.
+    fn instance(&self) -> AccountInfo<'info>;
 }
 
 /// A data structure that can be serialized and stored into account storage,
@@ -255,9 +255,9 @@ pub mod prelude {
     pub use super::{
         access_control, account, declare_id, emit, error, event, interface, program, require,
         state, zero_copy, Account, AccountDeserialize, AccountLoader, AccountSerialize, Accounts,
-        AccountsExit, AnchorDeserialize, AnchorSerialize, Context, CpiContext, Id, Key, Loader,
-        Owner, Program, ProgramAccount, Signer, System, Sysvar, ToAccountInfo, ToAccountInfos,
-        ToAccountMetas, UncheckedAccount,
+        AccountsExit, AnchorDeserialize, AnchorSerialize, Context, CpiContext, HasSingletonAccount,
+        Id, Key, Loader, Owner, Program, ProgramAccount, Signer, System, Sysvar, ToAccountInfo,
+        ToAccountInfos, ToAccountMetas, UncheckedAccount,
     };
 
     #[allow(deprecated)]

--- a/lang/syn/src/codegen/accounts/has_singleton_account.rs
+++ b/lang/syn/src/codegen/accounts/has_singleton_account.rs
@@ -1,0 +1,38 @@
+use crate::{AccountField, AccountsStruct, Ty};
+use quote::quote;
+
+// Generates the [HasSingleton] trait implementation.
+pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
+    let name = &accs.ident;
+
+    let has_singletons: Vec<proc_macro2::TokenStream> = accs
+        .fields
+        .iter()
+        .map(|f: &AccountField| {
+            match f {
+                AccountField::CompositeField(_) => quote! {},
+                AccountField::Field(f) => {
+                    let field_name = &f.ident;
+                    match &f.ty {
+                        Ty::Program(ty) => {
+                            let path = &ty.account_type_path;
+                            quote! {
+                                #[automatically_derived]
+                                impl anchor_lang::HasSingletonAccount<#path> for #name {
+                                    fn get_account_info(&self) -> anchor_lang::solana_program::account_info::AccountInfo<'info> {
+                                        self.#field_name
+                                    }
+                                }
+                            }
+                        },
+                        _ => quote!{}
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        #(#has_singletons)*
+    }
+}

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -9,6 +9,7 @@ mod __client_accounts;
 mod __cpi_client_accounts;
 mod constraints;
 mod exit;
+mod has_singleton_account;
 mod to_account_infos;
 mod to_account_metas;
 mod try_accounts;
@@ -17,6 +18,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
     let impl_try_accounts = try_accounts::generate(accs);
     let impl_to_account_infos = to_account_infos::generate(accs);
     let impl_to_account_metas = to_account_metas::generate(accs);
+    let impl_has_singleton_account = has_singleton_account::generate(accs);
     let impl_exit = exit::generate(accs);
 
     let __client_accounts_mod = __client_accounts::generate(accs);

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -28,6 +28,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         #impl_try_accounts
         #impl_to_account_infos
         #impl_to_account_metas
+        #impl_has_singleton_account
         #impl_exit
 
         #__client_accounts_mod


### PR DESCRIPTION
Allows one to fetch the singleton `AccountInfo` instance associated with an `Accounts` struct.

This lets one theoretically not have to explicitly pass in each account, with a second (unwritten) macro that checks for the presence of a `HasSingletonAccount` trait.

Ref: https://twitter.com/0xGoki/status/1451802462562799616