### PR TITLE
Fix anchor usage in browser by making getProvider async

### DIFF
--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -250,12 +250,8 @@ export class Program<IDL extends Idl = Idl> {
    * @param provider  The network and wallet context to use. If not provided
    *                  then uses [[getProvider]].
    */
-  public constructor(idl: IDL, programId: Address, provider?: Provider) {
+  public constructor(idl: IDL, programId: Address, provider: Provider) {
     programId = translateAddress(programId);
-
-    if (!provider) {
-      provider = getProvider();
-    }
 
     // Fields.
     this._idl = idl;
@@ -292,7 +288,7 @@ export class Program<IDL extends Idl = Idl> {
    */
   public static async at<IDL extends Idl = Idl>(
     address: Address,
-    provider?: Provider
+    provider: Provider
   ): Promise<Program<IDL>> {
     const programId = translateAddress(address);
 
@@ -315,9 +311,8 @@ export class Program<IDL extends Idl = Idl> {
    */
   public static async fetchIdl<IDL extends Idl = Idl>(
     address: Address,
-    provider?: Provider
+    provider: Provider
   ): Promise<IDL | null> {
-    provider = provider ?? getProvider();
     const programId = translateAddress(address);
 
     const idlAddr = await idlAddress(programId);

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -27,7 +27,7 @@ export default class AccountFactory {
     idl: IDL,
     coder: Coder,
     programId: PublicKey,
-    provider?: Provider
+    provider: Provider
   ): AccountNamespace<IDL> {
     const accountFns: AccountNamespace = {};
 
@@ -119,12 +119,12 @@ export class AccountClient<
     idl: IDL,
     idlAccount: A,
     programId: PublicKey,
-    provider?: Provider,
+    provider: Provider,
     coder?: Coder
   ) {
     this._idlAccount = idlAccount;
     this._programId = programId;
-    this._provider = provider ?? getProvider();
+    this._provider = provider;
     this._coder = coder ?? new Coder(idl);
     this._size =
       ACCOUNT_DISCRIMINATOR_SIZE + (accountSize(idl, idlAccount) ?? 0);

--- a/ts/src/program/namespace/state.ts
+++ b/ts/src/program/namespace/state.ts
@@ -30,7 +30,7 @@ export default class StateFactory {
     idl: IDL,
     coder: Coder,
     programId: PublicKey,
-    provider?: Provider
+    provider: Provider
   ): StateClient<IDL> | undefined {
     if (idl.state === undefined) {
       return undefined;
@@ -83,7 +83,7 @@ export class StateClient<IDL extends Idl> {
     /**
      * Returns the client's wallet and network provider.
      */
-    public readonly provider: Provider = getProvider(),
+    public readonly provider: Provider,
     /**
      * Returns the coder.
      */

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -229,14 +229,14 @@ export class NodeWallet implements Wallet {
   constructor(readonly payer: Keypair) {}
 
   static async local(): Promise<NodeWallet> {
-    const process = require("process");
+    const process = await import("process");
     const fs = await import('fs');
     const payer = Keypair.fromSecretKey(
       Buffer.from(
         JSON.parse(
-          fs.readFileSync(process.env.ANCHOR_WALLET, {
+          fs.readFileSync(process.env.ANCHOR_WALLET as string, {
             encoding: "utf-8",
-          })
+          }).toString()
         )
       )
     );

--- a/ts/src/utils/rpc.ts
+++ b/ts/src/utils/rpc.ts
@@ -24,7 +24,7 @@ export async function invoke(
 ): Promise<TransactionSignature> {
   programId = translateAddress(programId);
   if (!provider) {
-    provider = getProvider();
+    provider = await getProvider();
   }
 
   const tx = new Transaction();

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "module": "es2020",
-    "target": "es2019",
+    "target": "es2020",
 
     "outDir": "dist/esm/",
     "rootDir": "./src",

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["./src/**/*"],
   "compilerOptions": {
     "moduleResolution": "node",
-    "module": "es6",
+    "module": "es2020",
     "target": "es2019",
 
     "outDir": "dist/esm/",


### PR DESCRIPTION
Right now this code depends on `fs` and `process` which only exist in the Node. So when you try to use Anchor code in the browser, your app crashes (see #244, #983, and #728).

I believe this happens because Anchor is using `require('fs')` which JS is hoisting to the top of the file. (I haven't found documentation to support this guess, but it aligns with my testing.)

I updated the code to use the new [ES Module dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_import) — `await import('fs')`. 

This changes the sync `require('fs')` to an async `await import('fs')`. Correspondingly, I had to change some other code to be async. 

At a high level, I think Anchor would be easier to use and develop on top of if it tried to do less magical things. There are a lot of places where Anchor will try to find the right config or import a config file. It would be easier for the developer to just specify the config or IDL file manually. Then Anchor could have less external dependencies and be easier to understand.