### PR TITLE
Initial documentation for typescript client

### DIFF
--- a/docs/src/client/types.md
+++ b/docs/src/client/types.md
@@ -1,0 +1,74 @@
+
+## Getting TypeScript Types for the Anchor Program. 
+
+lets say we have a IDL definition for out program like this:
+
+```typescript
+export type AnchorVoting = {
+  "version": "0.0.0",
+  "name": "anchor_voting",
+  "instructions": [],
+  "accounts: [
+    {
+      "name": "baseAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "totalProposalCount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+  ],
+  "types": [
+    {
+      "name": "Proposal",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "title",
+            "type": "string"
+          },
+        ]
+      }
+    }
+  ],
+  "errors": []
+}
+```
+
+if you would like to use the account type definition in your code you can use the following code:
+
+```ts
+  import { IdlAccounts } from "@project-serum/anchor";
+
+  interface {
+    baseAccount: IdlAccounts<AnchorVoting>["baseAccount"];
+  }
+```
+
+
+## Getting struct types from the IDL
+
+Let's say we have a struct definition like this:
+
+```rust
+#[derive(Debug,  Clone, AnchorSerialize, AnchorDeserialize)]
+pub struct Proposal {
+    pub title: String,
+}
+```
+
+You can access to the struct type definition like this:
+
+```ts
+  import { IdlTypes } from "@project-serum/anchor";
+
+  interface {
+    proposal: IdlTypes<AnchorVoting>["Proposal"];
+  }
+```
+

--- a/docs/src/client/types.md
+++ b/docs/src/client/types.md
@@ -7,7 +7,29 @@ lets say we have a IDL definition for out program like this:
 export type AnchorVoting = {
   "version": "0.0.0",
   "name": "anchor_voting",
-  "instructions": [],
+  "instructions": [
+    {
+      "name": "initializeVoting",
+      "accounts": [
+        {
+          "name": "baseAccount",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "user",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
+    },
+  ],
   "accounts: [
     {
       "name": "baseAccount",
@@ -36,11 +58,23 @@ export type AnchorVoting = {
       }
     }
   ],
-  "errors": []
+  "errors": [
+    {
+      "code": 300,
+      "name": "YouAlreadyVotedForThisProposal",
+      "msg": "You have already voted for this proposal"
+    },
+  ]
 }
 ```
 
 if you would like to use the account type definition in your code you can use the following code:
+```rust 
+#[account]
+pub struct BaseAccount {
+    pub total_proposal_count: u64,
+}
+```
 
 ```ts
   import { IdlAccounts } from "@project-serum/anchor";
@@ -49,7 +83,6 @@ if you would like to use the account type definition in your code you can use th
     baseAccount: IdlAccounts<AnchorVoting>["baseAccount"];
   }
 ```
-
 
 ## Getting struct types from the IDL
 
@@ -72,3 +105,24 @@ You can access to the struct type definition like this:
   }
 ```
 
+## Getting error types from the IDL
+
+Let's say we have a error definition like this:
+
+```rust
+#[error]
+pub enum ErrorCode {
+    #[msg("You have already voted for this proposal")]
+    YouAlreadyVotedForThisProposal,
+}
+```
+
+Example of how to access the error type definition:
+
+```ts
+  import { IdlErrors} from "@project-serum/anchor";
+
+  interface {
+    error: IdlErrors<AnchorVoting>["YouAlreadyVotedForThisProposal"];
+  }
+```


### PR DESCRIPTION
I would like to contribute by adding documentation to the ts client side. 

My road map will be like this: (WIP)
### Types.


- [x] add documentation for how to access account types 
- [x] add documentation for how to access struct types 
- [x] add documentation for how to access error types
