### PR TITLE
Add undefined type and handling for Providers.Wallet

### DIFF
--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -162,6 +162,10 @@ export default class Provider {
 
     const sigs: TransactionSignature[] = [];
 
+    if (signedTxs === undefined) {
+      throw new Error("Failed to sign all transactions.");
+    }
+
     for (let k = 0; k < txs.length; k += 1) {
       const tx = signedTxs[k];
       const rawTx = tx.serialize();
@@ -221,8 +225,8 @@ export type SendTxRequest = {
  * Wallet interface for objects that can be used to sign provider transactions.
  */
 export interface Wallet {
-  signTransaction(tx: Transaction): Promise<Transaction>;
-  signAllTransactions(txs: Transaction[]): Promise<Transaction[]>;
+  signTransaction(tx: Transaction): Promise<Transaction> | undefined;
+  signAllTransactions(txs: Transaction[]): Promise<Transaction[]> | undefined;
   publicKey: PublicKey;
 }
 


### PR DESCRIPTION
I think it would be nice to support the `useWallet` in [@solana/wallet-adapter-react](https://github.com/solana-labs/wallet-adapter). 

The interfaces are actually similar: 

- [solana-labs wallet](https://github.com/solana-labs/wallet-adapter/blob/51e9559dca1d917caa511a0417f8deaac94d44e6/packages/core/react/src/useWallet.ts#L11-L26) 
```ts
export interface WalletContextState extends Omit<WalletAdapterProps, 'ready'> {
    wallets: Wallet[];
    autoConnect: boolean;

    wallet: Wallet | null;
    adapter: Adapter | null;
    ready: boolean;
    disconnecting: boolean;

    select(walletName: WalletName): void;

    signTransaction: SignerWalletAdapterProps['signTransaction'] | undefined;
    signAllTransactions: SignerWalletAdapterProps['signAllTransactions'] | undefined;

    signMessage: MessageSignerWalletAdapterProps['signMessage'] | undefined;
}
export interface SignerWalletAdapterProps {
    signTransaction(transaction: Transaction): Promise<Transaction>;
    signAllTransactions(transaction: Transaction[]): Promise<Transaction[]>;
}
```

- [Anchor wallet](https://github.com/project-serum/anchor/blob/master/ts/src/provider.ts#L223-L227)
```ts
export interface Wallet {
  signTransaction(tx: Transaction): Promise<Transaction>;
  signAllTransactions(txs: Transaction[]): Promise<Transaction[]>;
  publicKey: PublicKey;
}
```

