### PR TITLE
feat: Handle tuple structs in IDL

### DIFF
--- a/lang/syn/src/idl/file.rs
+++ b/lang/syn/src/idl/file.rs
@@ -413,7 +413,28 @@ fn parse_ty_defs(ctx: &CrateContext) -> Result<Vec<IdlTypeDefinition>> {
                         })
                     })
                     .collect::<Result<Vec<IdlField>>>(),
-                syn::Fields::Unnamed(_) => return None,
+                syn::Fields::Unnamed(fields) => {
+                    let mut i = -1;
+                    fields
+                        .unnamed
+                        .iter()
+                        .map(|f: &syn::Field| {
+                            let mut tts = proc_macro2::TokenStream::new();
+                            f.ty.to_tokens(&mut tts);
+                            // Handle array sizes that are constants
+                            let mut tts_string = tts.to_string();
+                            if tts_string.starts_with('[') {
+                                tts_string = resolve_variable_array_length(ctx, tts_string);
+                            }
+                            i += 1;
+
+                            Ok(IdlField {
+                                name: format!("f{}", i), // name fields as f0, f1, f2, ...
+                                ty: tts_string.parse()?,
+                            })
+                        })
+                        .collect::<Result<Vec<IdlField>>>()
+                }
                 _ => panic!("Empty structs are allowed."),
             };
 


### PR DESCRIPTION
This PR adds support for handling tuple structs in IDL. It names the tuple struct fields as `f0`, `f1`, `f2`, etc. The integer after `f` is the index of the value in the tuple.

Given a tuple struct in Rust like this:
```
#[account]
pub struct TupleStruct(u64, String, B, [i32; 5]);
```

The generated IDL looks like this:
```
    {
      "name": "TupleStruct",
      "type": {
        "kind": "struct",
        "fields": [
          {
            "name": "f0",
            "type": "u64"
          },
          {
            "name": "f1",
            "type": "string"
          },
          {
            "name": "f2",
            "type": {
              "defined": "B"
            }
          },
          {
            "name": "f3",
            "type": {
              "array": [
                "i32",
                5
              ]
            }
          }
        ]
      }
    }
```

Related to #232, #971.