### PR TITLE
cli: de-duplicate IDL JSON in TS types

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -35,14 +35,12 @@ pub fn idl_ts(idl: &Idl) -> Result<String> {
     }
     let idl_json = serde_json::to_string_pretty(&idl)?;
     Ok(format!(
-        r#"export type {} = {};
+        r#"export const IDL = {} as const;
 
-export const IDL: {} = {};
+export type {} = typeof IDL;
 "#,
-        idl.name.to_camel_case(),
         idl_json,
-        idl.name.to_camel_case(),
-        idl_json
+        idl.name.to_camel_case()
     ))
 }
 


### PR DESCRIPTION
I haven't tested this locally yet (will do tomorrow if this is considered useful), I'm just getting reacquainted with IDL stuff that's been added over the past few months.

One of the things I noticed was that the IDL object is included twice in generated typescript types file. I assume the reasoning behind this was because the types were too generic?

If that's the case using `as const` should mean that you don't need to duplicate the JSON in the file as the type would effectively be a readonly representation of the object.

before: without as const, `version` is `string` | after: with as const, `version` is `readonly "0.1.0"`
----|-----
<img width="524" alt="Screenshot 2021-12-31 at 12 06 00 AM" src="https://user-images.githubusercontent.com/601961/147795480-86fa154d-bae5-45d3-87e5-08b0fe64854d.png">|<img width="611" alt="Screenshot 2021-12-31 at 12 05 51 AM" src="https://user-images.githubusercontent.com/601961/147795482-362c15c2-1dab-415e-a543-6d5553bfbcf6.png">

