### PR TITLE
Fix account discriminator being incorrectly calculated

### DIFF
--- a/ts/src/coder/borsh/accounts.ts
+++ b/ts/src/coder/borsh/accounts.ts
@@ -94,8 +94,9 @@ export class BorshAccountsCoder<A extends string = string>
    * @param name The name of the account to calculate the discriminator.
    */
   public static accountDiscriminator(name: string): Buffer {
-    return Buffer.from(
-      sha256.digest(`account:${name}`)
-    ).slice(0, ACCOUNT_DISCRIMINATOR_SIZE);
+    return Buffer.from(sha256.digest(`account:${name}`)).slice(
+      0,
+      ACCOUNT_DISCRIMINATOR_SIZE
+    );
   }
 }

--- a/ts/src/coder/borsh/accounts.ts
+++ b/ts/src/coder/borsh/accounts.ts
@@ -95,7 +95,7 @@ export class BorshAccountsCoder<A extends string = string>
    */
   public static accountDiscriminator(name: string): Buffer {
     return Buffer.from(
-      sha256.digest(`account:${camelcase(name, { pascalCase: true })}`)
+      sha256.digest(`account:${name}`)
     ).slice(0, ACCOUNT_DISCRIMINATOR_SIZE);
   }
 }


### PR DESCRIPTION
When trying to create an account discriminator for an account struct that isn't pascal case anchor-ts, due to using the camelCase function, tries to get the discriminator using an incorrect name. 

Example
The accounts struct is defined to be `CereumUIAccount`
The discriminator is given by `SHA256("account:CereumUIAccount")`

The camel case function causes the discriminator to be calculated like this:
`SHA256("account:CereumUiAccount")`

causing the error `Invalid account discriminator` when fetching the account
