### PR TITLE
Updated Solana installation version in the docs

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -18,7 +18,7 @@ rustup component add rustfmt
 See the solana [docs](https://docs.solana.com/cli/install-solana-cli-tools) for installation instructions. On macOS and Linux,
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.9.1/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v1.9.4/install)"
 ```
 
 ## Install Yarn


### PR DESCRIPTION
Updated Solana installation version from `v1.9.1` -> `v1.9.4` as specified in the Solana [docs](https://docs.solana.com/cli/install-solana-cli-tools#macos--linux).