### PR TITLE
make `close` function public

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -34,7 +34,7 @@ mod account_meta;
 pub mod accounts;
 mod bpf_upgradeable_state;
 mod bpf_writer;
-mod common;
+pub mod common;
 pub mod context;
 mod ctor;
 pub mod error;


### PR DESCRIPTION
There's only one function in the common folder but it's quite useful, it's a util for closing accounts and returning the rent. Seems like there's no reason not to make it public / easily available