### PR TITLE
Enable dynamic ownership checks with account constraint

### DIFF
--- a/lang/src/accounts/boxed.rs
+++ b/lang/src/accounts/boxed.rs
@@ -13,7 +13,9 @@
 //! }
 //! ```
 
-use crate::{Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas, UnsafeAccounts,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
@@ -21,6 +23,17 @@ use std::collections::BTreeMap;
 use std::ops::Deref;
 
 impl<'info, T: Accounts<'info>> Accounts<'info> for Box<T> {
+    fn try_accounts(
+        program_id: &Pubkey,
+        accounts: &mut &[AccountInfo<'info>],
+        ix_data: &[u8],
+        bumps: &mut BTreeMap<String, u8>,
+    ) -> Result<Self> {
+        T::try_accounts(program_id, accounts, ix_data, bumps).map(Box::new)
+    }
+}
+
+impl<'info, T: UnsafeAccounts<'info>> UnsafeAccounts<'info> for Box<T> {
     fn try_accounts(
         program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -85,6 +85,15 @@ pub trait Accounts<'info>: ToAccountMetas + ToAccountInfos<'info> + Sized {
     ) -> Result<Self>;
 }
 
+pub trait UnsafeAccounts<'info>: ToAccountMetas + ToAccountInfos<'info> + Sized {
+    fn try_accounts(
+        program_id: &Pubkey,
+        accounts: &mut &[AccountInfo<'info>],
+        ix_data: &[u8],
+        bumps: &mut BTreeMap<String, u8>,
+    ) -> Result<Self>;
+}
+
 /// The exit procedure for an account. Any cleanup or persistence to storage
 /// should be done here.
 pub trait AccountsExit<'info>: ToAccountMetas + ToAccountInfos<'info> {

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -292,7 +292,7 @@ pub fn generate_constraint_owner(f: &Field, c: &ConstraintOwner) -> proc_macro2:
     );
     quote! {
         {
-            let my_owner = AsRef::<AccountInfo>::as_ref(&#ident).owner;
+            let my_owner = #ident.to_account_info().owner;
             let owner_address = #owner_address;
             if my_owner != &owner_address {
                 return #error;

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -52,7 +52,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         quote! {
                             #[cfg(feature = "anchor-debug")]
                             ::solana_program::log::sol_log(stringify!(#typed_name));
-                            let #typed_name = anchor_lang::Account::try_accounts_unchecked_owner(program_id, accounts, ix_data, __bumps)
+                            let #typed_name = anchor_lang::accounts::account::Account::try_accounts_unchecked_owner(program_id, accounts, ix_data, __bumps)
                                 .map_err(|e| e.with_account_name(#name))?;
                         }
                     } else {

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -43,8 +43,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         }
                     } else if let (Ty::Account(_), Some(_)) = (&f.ty, &f.constraints.owner) {
                         // The `owner` constraint on an account is redundant with the Owner trait
-                        // check done automatically in `try_accounts`. This special case calls
-                        // `try_accounts_unchecked_owner` instead.
+                        // check done automatically in `Accounts::try_accounts`. This special case calls
+                        // `UnsafeAccounts::try_accounts` instead.
                         // TODO:
                         //   Probably also want to support other Account types which deserialize data
                         let name = f.ident.to_string();
@@ -52,7 +52,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         quote! {
                             #[cfg(feature = "anchor-debug")]
                             ::solana_program::log::sol_log(stringify!(#typed_name));
-                            let #typed_name = anchor_lang::accounts::account::Account::try_accounts_unchecked_owner(program_id, accounts, ix_data, __bumps)
+                            let #typed_name = anchor_lang::UnsafeAccounts::try_accounts(program_id, accounts, ix_data, __bumps)
                                 .map_err(|e| e.with_account_name(#name))?;
                         }
                     } else {


### PR DESCRIPTION
Essentially my use case is that I have some `Account` fields which hold data owned by another program. However, the address of the external program is not static, since it may have been re-deployed to a private instance. I would like to verify that the owner matches the address that has been stored in one of my own program's PDAs, but Anchor currently requires that I implement `Owner` which returns a static address.

An example of what I mean:
```
// NOTE: owner constraint here refers to another account in the instruction
//   this is not possible in Anchor today because `Governance` must implement `Owner`
//   and return a static Pubkey
#[account(
    signer,
    seeds = [b"token-governance", realm.as_ref(), governance_authority.governed_account.as_ref()],
    bump,
    seeds::program = expense_manager.external_program_id,
    owner = expense_manager.external_program_id
)]
pub governance_authority: Account<'info, Governance>
```


To do this, I made a few changes:
1. I removed the `Owner` trait bounds on all `Account` impl blocks aside from the ones which deal with `Accounts::try_accounts`
2. I created a separate trait called `UnsafeAccounts` and implemented it on `Account` and `Box<T: UnsafeAccounts>` which is essentially identical except it skips the ownership check during deserialization which depends on `Owner`
3. I modified the codegen in the `Accounts` derive macro to detect when an `AccountField` has an `owner` constraint, and in that case uses `UnsafeAccounts::try_accounts` rather than `Accounts::try_accounts` to implement `Accounts::try_accounts` for the struct itself.

The results of this are:
1. The `Account` struct can now hold structs which do NOT implement `Owner` in the `account` field, and all traits except `Accounts` should work as before.
2. If an `Account` holds a struct which does not implement `Owner`, and there is no `owner` constraint on the field, and it is part of a struct which derives `Accounts`, the derive macro will panic (since `Accounts::try_accounts` trait bound will fail).
3. If an `Account` holds a struct which does not implement `Owner`, and there IS an `owner` constraint on the field, and it is part of a struct which derives `Accounts`, the derive macro will succeed. The owner constraint will be the only ownership check performed during deserialization.

-------
Other options considered:
- using `UncheckedAccount`: this adds significant complexity to the application since deserialization is still needed, particularly if the account's data is used elsewhere in constraints
- a new `UnsafeOwnerAccount` type: implemented about 50% of this and decided it caused too much code duplication and would be buggy to maintain as a result
- create some sort of wrapper type which would hold an instance of `Account`: I'm not confident I could implement this cleanly in Rust, and it would have pretty nasty interactions with `Box` which relies on some parser hacks atm