### PR TITLE
cli: prevent print deploy success when not found

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2405,12 +2405,15 @@ fn deploy(
         println!("Deploying workspace: {}", url);
         println!("Upgrade authority: {}", keypair);
 
+        let mut found = false;
+
         for mut program in cfg.read_all_programs()? {
             if let Some(single_prog_str) = &program_str {
                 let program_name = program.path.file_name().unwrap().to_str().unwrap();
                 if single_prog_str.as_str() != program_name {
                     continue;
                 }
+                found = true;
             }
             let binary_path = program.binary_path().display().to_string();
 
@@ -2460,7 +2463,11 @@ fn deploy(
             }
         }
 
-        println!("Deploy success");
+        if found {
+            println!("Deploy success");
+        } else {
+            println!("Program not found!");
+        }
 
         Ok(())
     })


### PR DESCRIPTION
Prevent CLI printing `Deploy Success` when the program is not found #1874