### PR TITLE
update examples to new `program.methods` syntax

### DIFF
--- a/examples/tutorial/basic-0/tests/basic-0.js
+++ b/examples/tutorial/basic-0/tests/basic-0.js
@@ -10,7 +10,7 @@ describe("basic-0", () => {
     const program = anchor.workspace.Basic0;
 
     // Execute the RPC.
-    await program.rpc.initialize();
+    await program.methods.initialize().rpc();
     // #endregion code
   });
 });

--- a/examples/tutorial/basic-1/tests/basic-1.js
+++ b/examples/tutorial/basic-1/tests/basic-1.js
@@ -19,14 +19,15 @@ describe("basic-1", () => {
 
     // Create the new account and initialize it with the program.
     // #region code-simplified
-    await program.rpc.initialize(new anchor.BN(1234), {
-      accounts: {
+		await program.methods
+			.initialize(new anchor.BN(1234))
+			.accounts({
         myAccount: myAccount.publicKey,
         user: provider.wallet.publicKey,
         systemProgram: SystemProgram.programId,
-      },
-      signers: [myAccount],
-    });
+			})
+			.signers([myAccount])
+			.rpc();
     // #endregion code-simplified
 
     // Fetch the newly created account from the cluster.
@@ -48,11 +49,12 @@ describe("basic-1", () => {
     const program = anchor.workspace.Basic1;
 
     // Invoke the update rpc.
-    await program.rpc.update(new anchor.BN(4321), {
-      accounts: {
+		await program.methods
+			.update(new anchor.BN(4321))
+			.accounts({
         myAccount: myAccount.publicKey,
-      },
-    });
+			})
+			.rpc();
 
     // Fetch the newly updated account.
     const account = await program.account.myAccount.fetch(myAccount.publicKey);

--- a/examples/tutorial/basic-2/tests/basic-2.js
+++ b/examples/tutorial/basic-2/tests/basic-2.js
@@ -15,14 +15,15 @@ describe("basic-2", () => {
   const program = anchor.workspace.Basic2;
 
   it("Creates a counter", async () => {
-    await program.rpc.create(provider.wallet.publicKey, {
-      accounts: {
+		await program.methods
+			.create(provider.wallet.publicKey)
+			.accounts({
         counter: counter.publicKey,
         user: provider.wallet.publicKey,
         systemProgram: SystemProgram.programId,
-      },
-      signers: [counter],
-    });
+			})
+			.signers([counter])
+			.rpc();
 
     let counterAccount = await program.account.counter.fetch(counter.publicKey);
 
@@ -31,12 +32,13 @@ describe("basic-2", () => {
   });
 
   it("Updates a counter", async () => {
-    await program.rpc.increment({
-      accounts: {
+		await program.methods
+			.increment()
+			.accounts({
         counter: counter.publicKey,
         authority: provider.wallet.publicKey,
-      },
-    });
+			})
+			.rpc();
 
     const counterAccount = await program.account.counter.fetch(
       counter.publicKey

--- a/examples/tutorial/basic-3/tests/basic-3.js
+++ b/examples/tutorial/basic-3/tests/basic-3.js
@@ -14,22 +14,24 @@ describe("basic-3", () => {
 
     // Initialize a new puppet account.
     const newPuppetAccount = anchor.web3.Keypair.generate();
-    const tx = await puppet.rpc.initialize({
-      accounts: {
+		const tx = await puppet.methods
+			.initialize()
+			.accounts({
         puppet: newPuppetAccount.publicKey,
         user: provider.wallet.publicKey,
         systemProgram: SystemProgram.programId,
-      },
-      signers: [newPuppetAccount],
-    });
+			})
+			.signers([newPuppetAccount])
+			.rpc();
 
     // Invoke the puppet master to perform a CPI to the puppet.
-    await puppetMaster.rpc.pullStrings(new anchor.BN(111), {
-      accounts: {
+		await puppetMaster.methods
+			.pullStrings(new anchor.BN(111))
+			.accounts({
         puppet: newPuppetAccount.publicKey,
         puppetProgram: puppet.programId,
-      },
-    });
+			})
+			.rpc();
 
     // Check the state updated.
     puppetAccount = await puppet.account.data.fetch(newPuppetAccount.publicKey);


### PR DESCRIPTION
basic-4 is still a to-do here. As the program is deprecated for this one, updating just the tests for it would result in them not working.

Maybe having the first three taken care of and working saves you a little time, so I thought I would just open a PR if you want to use this.

