### PR TITLE
Fix not being able to import Wallet interface

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -23,5 +23,4 @@ export declare const workspace: Record<string, Program>;
 
 if (!isBrowser) {
   exports.workspace = require("./workspace.js").default;
-  exports.Wallet = require("./nodewallet.js").default;
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -9,7 +9,7 @@ export {
   getProvider,
   setProvider,
   AnchorProvider,
-  Wallet
+  Wallet,
 } from "./provider.js";
 export * from "./error.js";
 export { Instruction } from "./coder/borsh/instruction.js";

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -1,13 +1,15 @@
-import NodeWallet from "./nodewallet";
+import { Program } from "./program/index.js";
 import { isBrowser } from "./utils/common.js";
 
 export { default as BN } from "bn.js";
 export * as web3 from "@solana/web3.js";
+export { default as NodeWallet } from "./nodewallet";
 export {
   default as Provider,
   getProvider,
   setProvider,
   AnchorProvider,
+  Wallet
 } from "./provider.js";
 export * from "./error.js";
 export { Instruction } from "./coder/borsh/instruction.js";
@@ -17,8 +19,7 @@ export * as utils from "./utils/index.js";
 export * from "./program/index.js";
 export * from "./spl/index.js";
 
-export declare const workspace: any;
-export declare class Wallet extends NodeWallet {}
+export declare const workspace: Record<string, Program>;
 
 if (!isBrowser) {
   exports.workspace = require("./workspace.js").default;


### PR DESCRIPTION
This exports `Wallet` interface, `NodeWallet` class. Previously the Wallet interface was inaccessible 

Also gave `workspace` a type `Record<string, Program>`

This is a breaking change. Should I fix tests?