### PR TITLE
Richer IDL generation with compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tests/*/Cargo.lock
 tests/**/Cargo.lock
 tests/*/yarn.lock
 tests/**/yarn.lock
+!tests/new-idl/programs/new-idl/src/bin
 .DS_Store
 docs/yarn.lock
 ts/docs/

--- a/lang/syn/src/idl/bin.rs
+++ b/lang/syn/src/idl/bin.rs
@@ -1,0 +1,164 @@
+use crate::idl::*;
+use crate::parser::context::CrateContext;
+use crate::parser::{self, accounts, docs, error, program};
+use crate::Ty;
+use crate::{AccountField, AccountsStruct, StateIx};
+use anyhow::Result;
+use heck::MixedCase;
+use quote::{ToTokens, quote, format_ident};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+const DERIVE_NAME: &str = "Accounts";
+// TODO: share this with `anchor_lang` crate.
+const ERROR_CODE_OFFSET: u32 = 6000;
+
+// Generate the source of the idl binary
+pub fn gen_src(
+    filename: impl AsRef<Path>,
+    version: String,
+    seeds_feature: bool,
+    no_docs: bool,
+    safety_checks: bool,
+) -> Result<Option<String>> {
+    let ctx = CrateContext::parse(filename)?;
+    if safety_checks {
+        ctx.safety_checks()?;
+    }
+
+    let program_mod = match parse_program_mod(&ctx) {
+        None => return Ok(None),
+        Some(m) => m,
+    };
+    let mut p = program::parse(program_mod)?;
+
+    if no_docs {
+        p.docs = None;
+        for ix in &mut p.ixs {
+            ix.docs = None;
+        }
+    }
+
+    let accs = parse_account_derives(&ctx);
+
+    let account_struct = accs.get("Initialize").unwrap();
+    let accounts = account_struct.fields.iter().map(|acc: &AccountField| {
+        match acc {
+            AccountField::CompositeField(_) => panic!("TODO"),
+            AccountField::Field(acc) => {
+                let name = acc.ident.to_string();
+                let is_mut = acc.constraints.is_mutable();
+                let is_signer = match acc.ty {
+                    Ty::Signer => true,
+                    _ => acc.constraints.is_signer()
+                };
+
+                let mut fields = vec![
+                    quote!("name": #name),
+                    quote!("isMut": #is_mut),
+                    quote!("isSigner": #is_signer),
+                    // TODO: docs
+                ];
+                
+                // pubkey
+                // TODO: also handle `Sysvar` and `address = <>` constraint
+                let pubkey = match &acc.ty {
+                    // transform from `Program<'info, SomeType>` to `SomeType::id().to_string()`
+                    Ty::Program(program) => program.account_type_path.path.get_ident().map(|i| quote!{#i::id().to_string()}),
+                    _ => None
+                };
+                pubkey.map(|pubkey| fields.push(quote!{"pubkey": #pubkey}));
+
+                // seeds
+                let seeds: Option<Vec<proc_macro2::TokenStream>> = acc.constraints.seeds.as_ref().map(|seeds| {
+                    // TODO: cover the cases when seed expression referencess instruction args or accounts
+                    seeds.seeds.iter().map(|seed| quote!{
+                        {
+                            "kind": "const",
+                            "type": "base58",
+                            "value": bs58::encode(#seed).into_string()
+                        }
+                    }).collect()
+                });
+                // TODO handle `seeds::program = <>` constraint
+                seeds.map(|seeds| fields.push(quote!("pda": {
+                    "seeds": [#(#seeds),*]
+                })));
+
+
+                quote!{
+                    {
+                       #(#fields),*
+                    }
+                }
+            }
+        }
+    });
+
+    
+    let ret = quote!{
+        use anchor_lang::prelude::*;
+        use std::str::FromStr;
+
+        const MY_SEED_U64: u64 = 3;
+
+        fn main() {
+            let instructions = serde_json::json!({
+                "instructions": [
+                    {
+                        "name": "initialize",
+                        "accounts": [#(#accounts),*],
+                        "args": []
+                    }
+                ]
+            });
+
+            println!("{}", serde_json::to_string_pretty(&instructions).unwrap());
+        }
+    };
+    
+    Ok(Some(format!("{}", ret)))
+}
+
+// Parse the main program mod.
+fn parse_program_mod(ctx: &CrateContext) -> Option<syn::ItemMod> {
+    let root = ctx.root_module();
+    let mods = root
+        .items()
+        .filter_map(|i| match i {
+            syn::Item::Mod(item_mod) => {
+                let mod_count = item_mod
+                    .attrs
+                    .iter()
+                    .filter(|attr| attr.path.segments.last().unwrap().ident == "program")
+                    .count();
+                if mod_count != 1 {
+                    return None;
+                }
+                Some(item_mod)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if mods.len() != 1 {
+        return None;
+    }
+    Some(mods[0].clone())
+}
+
+// Parse all structs implementing the `Accounts` trait.
+fn parse_account_derives(ctx: &CrateContext) -> HashMap<String, AccountsStruct> {
+    // TODO: parse manual implementations. Currently we only look
+    //       for derives.
+    ctx.structs()
+        .filter_map(|i_strct| {
+            for attr in &i_strct.attrs {
+                if attr.path.is_ident("derive") && attr.tokens.to_string().contains(DERIVE_NAME) {
+                    let strct = accounts::parse(i_strct).expect("Code not parseable");
+                    return Some((strct.ident.to_string(), strct));
+                }
+            }
+            None
+        })
+        .collect()
+}

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -3,6 +3,7 @@ use serde_json::Value as JsonValue;
 
 pub mod file;
 pub mod pda;
+pub mod bin;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Idl {

--- a/tests/new-idl/Anchor.toml
+++ b/tests/new-idl/Anchor.toml
@@ -1,0 +1,14 @@
+[features]
+seeds = true
+[programs.localnet]
+new_idl = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[registry]
+url = "https://anchor.projectserum.com"
+
+[provider]
+cluster = "localnet"
+wallet = "/home/work/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/new-idl/Cargo.toml
+++ b/tests/new-idl/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "programs/*"
+]

--- a/tests/new-idl/idl.json
+++ b/tests/new-idl/idl.json
@@ -1,0 +1,55 @@
+{
+  "instructions": [
+    {
+      "name": "initialize",
+      "accounts": [
+        {
+          "name": "state",
+          "isMut": true,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "base58",
+                "value": "11111111111111111111111111111111"
+              },
+              {
+                "kind": "const",
+                "type": "base58",
+                "value": "3tMg6nFceRK19FX3WY1Cbtu6DboaabhdVfeYP5BKqkuH"
+              },
+              {
+                "kind": "const",
+                "type": "base58",
+                "value": "W723RTUpoZ"
+              },
+              {
+                "kind": "const",
+                "type": "base58",
+                "value": "2UDrs33K4gNG3"
+              },
+              {
+                "kind": "const",
+                "type": "base58",
+                "value": "cM"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "system_program",
+          "isMut": false,
+          "isSigner": false,
+          "pubkey": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    }
+  ]
+}

--- a/tests/new-idl/package.json
+++ b/tests/new-idl/package.json
@@ -1,0 +1,19 @@
+{
+    "scripts": {
+        "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
+        "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
+    },
+    "dependencies": {
+        "@project-serum/anchor": "^0.24.2"
+    },
+    "devDependencies": {
+        "chai": "^4.3.4",
+        "mocha": "^9.0.3",
+        "ts-mocha": "^8.0.0",
+        "@types/bn.js": "^5.1.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^9.0.0",
+        "typescript": "^4.3.5",
+        "prettier": "^2.6.2"
+    }
+}

--- a/tests/new-idl/programs/new-idl/Cargo.toml
+++ b/tests/new-idl/programs/new-idl/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "new-idl"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "new_idl"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[profile.release]
+overflow-checks = true
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+bs58 = "0.4.0"

--- a/tests/new-idl/programs/new-idl/Xargo.toml
+++ b/tests/new-idl/programs/new-idl/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/new-idl/programs/new-idl/src/bin/idl.rs
+++ b/tests/new-idl/programs/new-idl/src/bin/idl.rs
@@ -1,0 +1,7 @@
+use anchor_lang::prelude::*;
+use std::str::FromStr;
+const MY_SEED_U64: u64 = 3;
+fn main() {
+    let instructions = serde_json :: json ! ({ "instructions" : [{ "name" : "initialize" , "accounts" : [{ "name" : "state" , "isMut" : true , "isSigner" : false , "pda" : { "seeds" : [{ "kind" : "const" , "type" : "base58" , "value" : bs58 :: encode (anchor_lang :: solana_program :: system_program :: ID . as_ref ()) . into_string () } , { "kind" : "const" , "type" : "base58" , "value" : bs58 :: encode (Pubkey :: from_str ("3tMg6nFceRK19FX3WY1Cbtu6DboaabhdVfeYP5BKqkuH") . unwrap () . as_ref ()) . into_string () } , { "kind" : "const" , "type" : "base58" , "value" : bs58 :: encode (& MY_SEED_U64 . to_le_bytes ()) . into_string () } , { "kind" : "const" , "type" : "base58" , "value" : bs58 :: encode (b"some-seed" . as_ref ()) . into_string () } , { "kind" : "const" , "type" : "base58" , "value" : bs58 :: encode (& [8 , 2]) . into_string () }] } } , { "name" : "payer" , "isMut" : true , "isSigner" : true } , { "name" : "system_program" , "isMut" : false , "isSigner" : false , "pubkey" : System :: id () . to_string () }] , "args" : [] }] });
+    println!("{}", serde_json::to_string_pretty(&instructions).unwrap());
+}

--- a/tests/new-idl/programs/new-idl/src/bin/idl_exp.rs
+++ b/tests/new-idl/programs/new-idl/src/bin/idl_exp.rs
@@ -1,0 +1,59 @@
+use anchor_lang::prelude::*;
+use std::str::FromStr;
+
+const MY_SEED_U64: u64 = 3;
+
+fn main() {
+    let instructions = serde_json::json!({
+        "instructions": [
+            {
+                "name": "initialize",
+                "accounts": [
+                    {
+                        "name": "state",
+                        "isMut": true,
+                        "isSigner": false,
+                        "pda": {
+                            "seeds": [
+                                {
+                                    "kind": "const",
+                                    "type": "base58",
+                                    "value": bs58::encode(anchor_lang::solana_program::system_program::ID.as_ref()).into_string(),
+                                },
+                                {
+                                    "kind": "const",
+                                    "type": "base58",
+                                    "value": bs58::encode(Pubkey::from_str("3tMg6nFceRK19FX3WY1Cbtu6DboaabhdVfeYP5BKqkuH").unwrap().as_ref()).into_string(),
+                                },
+                                {
+                                    "kind": "const",
+                                    "type": "base58",
+                                    "value": bs58::encode(&MY_SEED_U64.to_le_bytes()).into_string(),
+                                },
+                                {
+                                    "kind": "const",
+                                    "type": "base58",
+                                    "value": bs58::encode(b"some-seed".as_ref()).into_string(),
+                                },
+                            ],
+                        }
+                    },
+                    {
+                        "name": "payer",
+                        "isMut": true,
+                        "isSigner": true,
+                    },
+                    {
+                        "name": "systemProgram",
+                        "isMut": false,
+                        "isSigner": false,
+                        "pubkey": System::id().to_string()
+                    }
+                ],
+                "args": []
+            }
+        ]
+    });
+
+    println!("{}", serde_json::to_string_pretty(&instructions).unwrap());
+}

--- a/tests/new-idl/programs/new-idl/src/lib.rs
+++ b/tests/new-idl/programs/new-idl/src/lib.rs
@@ -1,0 +1,43 @@
+use anchor_lang::prelude::*;
+use std::str::FromStr;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+pub const MY_SEED_U64: u64 = 3;
+
+#[program]
+pub mod new_idl {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[account]
+pub struct State {
+    foo_bool: bool
+}
+
+#[derive(Accounts)]
+#[instruction(bump: u8)]
+pub struct Initialize<'info> {
+    #[account(
+        init,
+        payer = payer,
+        space = 8 + 1,
+        seeds = [
+            anchor_lang::solana_program::system_program::ID.as_ref(),
+            Pubkey::from_str("3tMg6nFceRK19FX3WY1Cbtu6DboaabhdVfeYP5BKqkuH").unwrap().as_ref(),
+            &MY_SEED_U64.to_le_bytes(),
+            b"some-seed".as_ref(),
+            &[8, 2]
+        ],
+        bump
+    )]
+    state: Account<'info, State>,
+
+    #[account(mut)]
+    payer: Signer<'info>,
+    system_program: Program<'info, System>,
+}

--- a/tests/new-idl/tests/new-idl.ts
+++ b/tests/new-idl/tests/new-idl.ts
@@ -1,0 +1,16 @@
+import * as anchor from "@project-serum/anchor";
+import { Program } from "@project-serum/anchor";
+import { NewIdl } from "../target/types/new_idl";
+
+describe("new-idl", () => {
+  // Configure the client to use the local cluster.
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const program = anchor.workspace.NewIdl as Program<NewIdl>;
+
+  it("Is initialized!", async () => {
+    // Add your test here.
+    const tx = await program.methods.initialize().rpc();
+    console.log("Your transaction signature", tx);
+  });
+});

--- a/tests/new-idl/tsconfig.json
+++ b/tests/new-idl/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
If we have a, for example, `Program<'info, SomeProgram>` constraint in the accounts, we know that the account with the SomeProgram::id() pubkey needs to be passed in, but we're not able to leverage this information from the clients because it's not encoded within the IDL (aside from the hack in anchor ts where we match by [account name](https://github.com/project-serum/anchor/blob/master/ts/src/program/accounts-resolver.ts#L62) only for specific accounts).

The reason this is not possible currently is because the IDL generation works by parsing the program source code which gives it access to the TokenStream (basically AST) but parsing the actual program ID of the referenced program from this is, to say the least, not practical.

In order to go around this, in this POC I've taken a slightly different approach. Instead of just parsing the program source and outputting the generated IDL, I've l codegened an intermediate binary which is then compiled and run to to print out the IDL. The benefit of this approach is that now instead of only having access to the AST, we can also evaluate expressions within the program source. 

So, referring to the the above example, with the binary we can do:
```
"pubkey": SomeProgram::id().to_string()
```
and when this is executed it will output
```
"pubkey": "<...>"
```
giving the possibility of encoding more information in the IDL.

Expression evaluation is not only useful for the Program constraint, but also for seeds, seeds::program, etc. Essentially, anything that does rely on an input to the ix call (ix arg, passed account, or account data) we can now evaluate and put in the IDL.

[Here's](https://github.com/kklas/anchor/blob/f6a76fd20a1427e216e4fd2450757ecf265b3b63/tests/new-idl/programs/new-idl/src/bin/idl_exp.rs) a more detailed example that was generated by this POC for a [test program](https://github.com/kklas/anchor/blob/f6a76fd20a1427e216e4fd2450757ecf265b3b63/tests/new-idl/programs/new-idl/src/lib.rs), and [this](https://github.com/kklas/anchor/blob/f6a76fd20a1427e216e4fd2450757ecf265b3b63/tests/new-idl/idl.json) is the IDL it generates (I've generated only the instructions field here for the POC but this would output the full IDL).

Notes:
- I’ve encoded the seeds as base58 which I think is really convenient
- I’ve added the optional pubkey field to account for when we know which account needs to be passed in (like with Program)

TODO:
- handle expressions which reference ix args or account inputs
  - we need to be careful not to just copy over the TokenStream into the binary source because if it references any inputs it will cause a compiler error
  - this can be handled similar to how the current pda parser works - we can whitelist expression types which we want to support (like the [MethodCall](https://docs.rs/syn/1.0.95/syn/enum.Expr.html#variant.MethodCall)) and comb through the AST to find any references to ix args or accounts. In that case we can put any info about which args or inputs are being referenced to the IDL if possible
- handle other constraints like `Sysvar`, `address = <>`, and `seeds::program = <>`
- handle modules

Consideration:
The POC command I've implemented generates the binary in the program source directory which is probably not ideal because it pollutes users codebase. We probably want to generate it in the `.anchor` directory or similar.
In that case we'd also need to copy the program's Cargo.toml in there to have the same dependencies. 

@armaniferrante let me know if this approach is valid so I can finish this up.