### PR TITLE
Idl usize

### DIFF
--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -180,6 +180,8 @@ pub enum EnumFields {
 #[serde(rename_all = "camelCase")]
 pub enum IdlType {
     Bool,
+    USize,
+    ISize,
     U8,
     I8,
     U16,
@@ -221,6 +223,8 @@ impl std::str::FromStr for IdlType {
 
         let r = match s.as_str() {
             "bool" => IdlType::Bool,
+            "usize" => IdlType::USize,
+            "isize" => IdlType::ISize,
             "u8" => IdlType::U8,
             "i8" => IdlType::I8,
             "u16" => IdlType::U16,

--- a/ts/src/coder/borsh/idl.ts
+++ b/ts/src/coder/borsh/idl.ts
@@ -15,6 +15,12 @@ export class IdlCoder {
       case "bool": {
         return borsh.bool(fieldName);
       }
+      case "usize": {
+        return borsh.u64(fieldName);
+      }
+      case "isize": {
+        return borsh.i64(fieldName);
+      }
       case "u8": {
         return borsh.u8(fieldName);
       }

--- a/ts/src/coder/common.ts
+++ b/ts/src/coder/common.ts
@@ -34,6 +34,10 @@ function typeSize(idl: Idl, ty: IdlType): number {
   switch (ty) {
     case "bool":
       return 1;
+    case "usize":
+      return 8;
+    case "isize":
+      return 8;
     case "u8":
       return 1;
     case "i8":

--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -108,6 +108,8 @@ export type IdlTypeDefStruct = Array<IdlField>;
 
 export type IdlType =
   | "bool"
+  | "usize"
+  | "isize"
   | "u8"
   | "i8"
   | "u16"

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -108,7 +108,7 @@ type TypeMap = {
 } & {
   [K in "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "f32" | "f64"]: number;
 } & {
-  [K in "u64" | "i64" | "u128" | "i128"]: BN;
+  [K in "usize" | "isize" | "u64" | "i64" | "u128" | "i128"]: BN;
 };
 
 export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap


### PR DESCRIPTION
This adds usize and isize parsing to the ts client.

Anchor already emits usize and isize from rust programs, but it was given the `unknown` type in ts

There's an assumption that size is always 8 bytes, but I'm not sure if architecture could change in some scenarios