### PR TITLE
lang: prevent duplicate mutable accounts in instruction

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -4,6 +4,7 @@ use anchor_syn::idl::Idl;
 use anyhow::Result;
 use heck::{CamelCase, MixedCase, SnakeCase};
 use solana_sdk::pubkey::Pubkey;
+use std::fmt::Write;
 
 pub fn default_program_id() -> Pubkey {
     "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
@@ -368,14 +369,15 @@ anchor.setProvider(provider);
     );
 
     for program in programs {
-        eval_string.push_str(&format!(
+        write!(
+            &mut eval_string,
             r#"
 anchor.workspace.{} = new anchor.Program({}, new PublicKey("{}"), provider);
 "#,
             program.name.to_camel_case(),
             serde_json::to_string(&program.idl)?,
             program.program_id
-        ));
+        )?;
     }
 
     Ok(eval_string)

--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -4,13 +4,12 @@ use crate::bpf_writer::BpfWriter;
 use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Owner,
-    Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    Result, ToAccountInfo, ToAccountInfos, ToAccountMetas, TryAccountsContext,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_program;
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
@@ -320,8 +319,7 @@ where
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/account_info.rs
+++ b/lang/src/accounts/account_info.rs
@@ -3,19 +3,19 @@
 //! should be used instead.
 
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas, TryAccountsContext,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 
 impl<'info> Accounts<'info> for AccountInfo<'info> {
     fn try_accounts(
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/account_loader.rs
+++ b/lang/src/accounts/account_loader.rs
@@ -4,14 +4,13 @@ use crate::bpf_writer::BpfWriter;
 use crate::error::{Error, ErrorCode};
 use crate::{
     Accounts, AccountsClose, AccountsExit, Key, Owner, Result, ToAccountInfo, ToAccountInfos,
-    ToAccountMetas, ZeroCopy,
+    ToAccountMetas, TryAccountsContext, ZeroCopy,
 };
 use arrayref::array_ref;
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::Write;
 use std::marker::PhantomData;
@@ -220,8 +219,7 @@ impl<'info, T: ZeroCopy + Owner> Accounts<'info> for AccountLoader<'info, T> {
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/boxed.rs
+++ b/lang/src/accounts/boxed.rs
@@ -13,11 +13,13 @@
 //! }
 //! ```
 
-use crate::{Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas,
+    TryAccountsContext,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 
 impl<'info, T: Accounts<'info>> Accounts<'info> for Box<T> {
@@ -25,10 +27,9 @@ impl<'info, T: Accounts<'info>> Accounts<'info> for Box<T> {
         program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         ix_data: &[u8],
-        bumps: &mut BTreeMap<String, u8>,
-        reallocs: &mut BTreeSet<Pubkey>,
+        ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
-        T::try_accounts(program_id, accounts, ix_data, bumps, reallocs).map(Box::new)
+        T::try_accounts(program_id, accounts, ix_data, ctx).map(Box::new)
     }
 }
 

--- a/lang/src/accounts/cpi_account.rs
+++ b/lang/src/accounts/cpi_account.rs
@@ -3,7 +3,6 @@ use crate::{error::ErrorCode, prelude::Account};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 
 /// Container for any account *not* owned by the current program.
@@ -52,8 +51,7 @@ where
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/cpi_state.rs
+++ b/lang/src/accounts/cpi_state.rs
@@ -3,12 +3,11 @@ use crate::error::ErrorCode;
 use crate::{accounts::state::ProgramState, context::CpiStateContext};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Key, Result, ToAccountInfos,
-    ToAccountMetas,
+    ToAccountMetas, TryAccountsContext,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::{Deref, DerefMut};
 
 /// Boxed container for the program state singleton, used when the state
@@ -71,8 +70,7 @@ where
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/loader.rs
+++ b/lang/src/accounts/loader.rs
@@ -2,14 +2,13 @@ use crate::bpf_writer::BpfWriter;
 use crate::error::{Error, ErrorCode};
 use crate::{
     Accounts, AccountsClose, AccountsExit, Key, Result, ToAccountInfo, ToAccountInfos,
-    ToAccountMetas, ZeroCopy,
+    ToAccountMetas, TryAccountsContext, ZeroCopy,
 };
 use arrayref::array_ref;
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 use std::cell::{Ref, RefMut};
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::io::Write;
 use std::marker::PhantomData;
@@ -162,8 +161,7 @@ impl<'info, T: ZeroCopy> Accounts<'info> for Loader<'info, T> {
         program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -3,12 +3,12 @@
 use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, Accounts, AccountsExit, Id, Key, Result, ToAccountInfos, ToAccountMetas,
+    TryAccountsContext,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -146,8 +146,7 @@ where
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/program_account.rs
+++ b/lang/src/accounts/program_account.rs
@@ -4,12 +4,11 @@ use crate::bpf_writer::BpfWriter;
 use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Result,
-    ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    ToAccountInfo, ToAccountInfos, ToAccountMetas, TryAccountsContext,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::{Deref, DerefMut};
 
 /// Boxed container for a deserialized `account`. Use this to reference any
@@ -82,8 +81,7 @@ where
         program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/signer.rs
+++ b/lang/src/accounts/signer.rs
@@ -1,10 +1,11 @@
 //! Type validating that the account signed the transaction
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas, TryAccountsContext,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 
 /// Type validating that the account signed the transaction. No other ownership
@@ -60,8 +61,7 @@ impl<'info> Accounts<'info> for Signer<'info> {
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/state.rs
+++ b/lang/src/accounts/state.rs
@@ -4,12 +4,11 @@ use crate::bpf_writer::BpfWriter;
 use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Key, Result, ToAccountInfo,
-    ToAccountInfos, ToAccountMetas,
+    ToAccountInfos, ToAccountMetas, TryAccountsContext,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::{Deref, DerefMut};
 
 pub const PROGRAM_STATE_SEED: &str = "unversioned";
@@ -73,8 +72,7 @@ where
         program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -6,7 +6,6 @@ use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_program;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 
 /// Type validating that the account is owned by the system program
@@ -39,8 +38,7 @@ impl<'info> Accounts<'info> for SystemAccount<'info> {
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/sysvar.rs
+++ b/lang/src/accounts/sysvar.rs
@@ -1,11 +1,12 @@
 //! Type validating that the account is a sysvar and deserializing it
 
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas, TryAccountsContext,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
@@ -70,8 +71,7 @@ impl<'info, T: solana_program::sysvar::Sysvar> Accounts<'info> for Sysvar<'info,
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/accounts/unchecked_account.rs
+++ b/lang/src/accounts/unchecked_account.rs
@@ -2,11 +2,12 @@
 //! that no checks are performed
 
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas, TryAccountsContext,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
-use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 
 /// Explicit wrapper for AccountInfo types to emphasize
@@ -25,8 +26,7 @@ impl<'info> Accounts<'info> for UncheckedAccount<'info> {
         _program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         _ix_data: &[u8],
-        _bumps: &mut BTreeMap<String, u8>,
-        _reallocs: &mut BTreeSet<Pubkey>,
+        _ctx: &mut TryAccountsContext,
     ) -> Result<Self> {
         if accounts.is_empty() {
             return Err(ErrorCode::AccountNotEnoughKeys.into());

--- a/lang/src/error.rs
+++ b/lang/src/error.rs
@@ -184,6 +184,9 @@ pub enum ErrorCode {
     /// 3017 - The account was duplicated for more than one reallocation
     #[msg("The account was duplicated for more than one reallocation")]
     AccountDuplicateReallocs,
+    /// 3018 - The account was duplicated in more than one mutable account info.
+    #[msg("The account was duplicated in more than one mutable account info.")]
+    AccountDuplicateMutables,
 
     // State.
     /// 4000 - The given state account does not have the correct address

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -359,7 +359,7 @@ pub mod __private {
 macro_rules! require {
     ($invariant:expr, $error:tt $(,)?) => {
         if !($invariant) {
-            return Err(anchor_lang::error!(crate::ErrorCode::$error));
+            return Err(anchor_lang::error!($crate::ErrorCode::$error));
         }
     };
     ($invariant:expr, $error:expr $(,)?) => {
@@ -568,7 +568,7 @@ macro_rules! require_gte {
 #[macro_export]
 macro_rules! err {
     ($error:tt $(,)?) => {
-        Err(anchor_lang::error!(crate::ErrorCode::$error))
+        Err(anchor_lang::error!($crate::ErrorCode::$error))
     };
     ($error:expr $(,)?) => {
         Err(anchor_lang::error!($error))

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -81,9 +81,15 @@ pub trait Accounts<'info>: ToAccountMetas + ToAccountInfos<'info> + Sized {
         program_id: &Pubkey,
         accounts: &mut &[AccountInfo<'info>],
         ix_data: &[u8],
-        bumps: &mut BTreeMap<String, u8>,
-        reallocs: &mut BTreeSet<Pubkey>,
+        ctx: &mut TryAccountsContext,
     ) -> Result<Self>;
+}
+
+#[derive(Default)]
+pub struct TryAccountsContext {
+    pub bumps: BTreeMap<String, u8>,
+    pub mutables: BTreeSet<Pubkey>,
+    pub reallocs: BTreeSet<Pubkey>,
 }
 
 /// The exit procedure for an account. Any cleanup or persistence to storage

--- a/lang/syn/src/codegen/accounts/try_accounts.rs
+++ b/lang/syn/src/codegen/accounts/try_accounts.rs
@@ -25,7 +25,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     quote! {
                         #[cfg(feature = "anchor-debug")]
                         ::solana_program::log::sol_log(stringify!(#name));
-                        let #name: #ty = anchor_lang::Accounts::try_accounts(program_id, accounts, ix_data, __bumps, __reallocs)?;
+                        let #name: #ty = anchor_lang::Accounts::try_accounts(program_id, accounts, ix_data, __ctx)?;
                     }
                 }
                 AccountField::Field(f) => {
@@ -47,7 +47,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         quote! {
                             #[cfg(feature = "anchor-debug")]
                             ::solana_program::log::sol_log(stringify!(#typed_name));
-                            let #typed_name = anchor_lang::Accounts::try_accounts(program_id, accounts, ix_data, __bumps, __reallocs)
+                            let #typed_name = anchor_lang::Accounts::try_accounts(program_id, accounts, ix_data, __ctx)
                                 .map_err(|e| e.with_account_name(#name))?;
                         }
                     }
@@ -97,8 +97,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                 program_id: &anchor_lang::solana_program::pubkey::Pubkey,
                 accounts: &mut &[anchor_lang::solana_program::account_info::AccountInfo<'info>],
                 ix_data: &[u8],
-                __bumps: &mut std::collections::BTreeMap<String, u8>,
-                __reallocs: &mut std::collections::BTreeSet<anchor_lang::solana_program::pubkey::Pubkey>,
+                __ctx: &mut anchor_lang::TryAccountsContext,
             ) -> anchor_lang::Result<Self> {
                 // Deserialize instruction, if declared.
                 #ix_de

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -25,42 +25,37 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
 
                 match ix {
                     anchor_lang::idl::IdlInstruction::Create { data_len } => {
-                        let mut bumps = std::collections::BTreeMap::new();
-                        let mut reallocs = std::collections::BTreeSet::new();
+                        let mut ctx = anchor_lang::TryAccountsContext::default();
                         let mut accounts =
-                            anchor_lang::idl::IdlCreateAccounts::try_accounts(program_id, &mut accounts, &[], &mut bumps, &mut reallocs)?;
+                            anchor_lang::idl::IdlCreateAccounts::try_accounts(program_id, &mut accounts, &[], &mut ctx)?;
                         __idl_create_account(program_id, &mut accounts, data_len)?;
                         accounts.exit(program_id)?;
                     },
                     anchor_lang::idl::IdlInstruction::CreateBuffer => {
-                        let mut bumps = std::collections::BTreeMap::new();
-                        let mut reallocs = std::collections::BTreeSet::new();
+                        let mut ctx = anchor_lang::TryAccountsContext::default();
                         let mut accounts =
-                            anchor_lang::idl::IdlCreateBuffer::try_accounts(program_id, &mut accounts, &[], &mut bumps, &mut reallocs)?;
+                            anchor_lang::idl::IdlCreateBuffer::try_accounts(program_id, &mut accounts, &[], &mut ctx)?;
                         __idl_create_buffer(program_id, &mut accounts)?;
                         accounts.exit(program_id)?;
                     },
                     anchor_lang::idl::IdlInstruction::Write { data } => {
-                        let mut bumps = std::collections::BTreeMap::new();
-                        let mut reallocs = std::collections::BTreeSet::new();
+                        let mut ctx = anchor_lang::TryAccountsContext::default();
                         let mut accounts =
-                            anchor_lang::idl::IdlAccounts::try_accounts(program_id, &mut accounts, &[], &mut bumps, &mut reallocs)?;
+                            anchor_lang::idl::IdlAccounts::try_accounts(program_id, &mut accounts, &[], &mut ctx)?;
                         __idl_write(program_id, &mut accounts, data)?;
                         accounts.exit(program_id)?;
                     },
                     anchor_lang::idl::IdlInstruction::SetAuthority { new_authority } => {
-                        let mut bumps = std::collections::BTreeMap::new();
-                        let mut reallocs = std::collections::BTreeSet::new();
+                        let mut ctx = anchor_lang::TryAccountsContext::default();
                         let mut accounts =
-                            anchor_lang::idl::IdlAccounts::try_accounts(program_id, &mut accounts, &[], &mut bumps, &mut reallocs)?;
+                            anchor_lang::idl::IdlAccounts::try_accounts(program_id, &mut accounts, &[], &mut ctx)?;
                         __idl_set_authority(program_id, &mut accounts, new_authority)?;
                         accounts.exit(program_id)?;
                     },
                     anchor_lang::idl::IdlInstruction::SetBuffer => {
-                        let mut bumps = std::collections::BTreeMap::new();
-                        let mut reallocs = std::collections::BTreeSet::new();
+                        let mut ctx = anchor_lang::TryAccountsContext::default();
                         let mut accounts =
-                            anchor_lang::idl::IdlSetBuffer::try_accounts(program_id, &mut accounts, &[], &mut bumps, &mut reallocs)?;
+                            anchor_lang::idl::IdlSetBuffer::try_accounts(program_id, &mut accounts, &[], &mut ctx)?;
                         __idl_set_buffer(program_id, &mut accounts)?;
                         accounts.exit(program_id)?;
                     },
@@ -220,15 +215,14 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
                             let instruction::state::#variant_arm = ix;
 
-                            let mut __bumps = std::collections::BTreeMap::new();
-                            let mut __reallocs = std::collections::BTreeSet::new();
+                            let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                             // Deserialize accounts.
                             let mut remaining_accounts: &[AccountInfo] = accounts;
                             let ctor_accounts =
-                            anchor_lang::__private::Ctor::try_accounts(program_id, &mut remaining_accounts, &[], &mut __bumps, &mut __reallocs)?;
+                            anchor_lang::__private::Ctor::try_accounts(program_id, &mut remaining_accounts, &[], &mut __ctx)?;
                             let mut ctor_user_def_accounts =
-                            #anchor_ident::try_accounts(program_id, &mut remaining_accounts, ix_data, &mut __bumps, &mut __reallocs)?;
+                            #anchor_ident::try_accounts(program_id, &mut remaining_accounts, ix_data, &mut __ctx)?;
 
                             // Create the solana account for the ctor data.
                             let from = ctor_accounts.from.key;
@@ -300,15 +294,14 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                 .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
                             let instruction::state::#variant_arm = ix;
 
-                            let mut __bumps = std::collections::BTreeMap::new();
-                            let mut __reallocs = std::collections::BTreeSet::new();
+                            let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                             // Deserialize accounts.
                             let mut remaining_accounts: &[AccountInfo] = accounts;
                             let ctor_accounts =
-                            anchor_lang::__private::Ctor::try_accounts(program_id, &mut remaining_accounts, &[], &mut __bumps, &mut __reallocs)?;
+                            anchor_lang::__private::Ctor::try_accounts(program_id, &mut remaining_accounts, &[], &mut __ctx)?;
                             let mut ctor_user_def_accounts =
-                            #anchor_ident::try_accounts(program_id, &mut remaining_accounts, ix_data, &mut __bumps, &mut __reallocs)?;
+                            #anchor_ident::try_accounts(program_id, &mut remaining_accounts, ix_data, &mut __ctx)?;
 
                             // Invoke the ctor.
                             let instance = #mod_name::#name::new(
@@ -409,26 +402,21 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                         .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
                                     let instruction::state::#variant_arm = ix;
 
-                                    // Bump collector.
-                                    let mut __bumps = std::collections::BTreeMap::new();
-
-                                    // Realloc tracker
-                                    let mut __reallocs= std::collections::BTreeSet::new();
+                                    let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                                     // Load state.
                                     let mut remaining_accounts: &[AccountInfo] = accounts;
                                     if remaining_accounts.is_empty() {
                                         return Err(anchor_lang::error::ErrorCode::AccountNotEnoughKeys.into());
                                     }
-                                    let loader: anchor_lang::accounts::loader::Loader<#mod_name::#name> = anchor_lang::accounts::loader::Loader::try_accounts(program_id, &mut remaining_accounts, &[], &mut __bumps, &mut __reallocs)?;
+                                    let loader: anchor_lang::accounts::loader::Loader<#mod_name::#name> = anchor_lang::accounts::loader::Loader::try_accounts(program_id, &mut remaining_accounts, &[], &mut __ctx)?;
 
                                     // Deserialize accounts.
                                     let mut accounts = #anchor_ident::try_accounts(
                                         program_id,
                                         &mut remaining_accounts,
                                         ix_data,
-                                        &mut __bumps,
-                                        &mut __reallocs,
+                                        &mut __ctx
                                     )?;
                                     let ctx =
                                         anchor_lang::context::Context::new(
@@ -469,11 +457,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                         .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
                                     let instruction::state::#variant_arm = ix;
 
-                                    // Bump collector.
-                                    let mut __bumps = std::collections::BTreeMap::new();
-
-                                    // Realloc tracker.
-                                    let mut __reallocs = std::collections::BTreeSet::new();
+                                    let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                                     // Load state.
                                     let mut remaining_accounts: &[AccountInfo] = accounts;
@@ -484,8 +468,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                         program_id,
                                         &mut remaining_accounts,
                                         &[],
-                                        &mut __bumps,
-                                        &mut __reallocs,
+                                        &mut __ctx,
                                     )?;
 
                                     // Deserialize accounts.
@@ -493,8 +476,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                         program_id,
                                         &mut remaining_accounts,
                                         ix_data,
-                                        &mut __bumps,
-                                        &mut __reallocs,
+                                        &mut __ctx,
                                     )?;
                                     let ctx =
                                         anchor_lang::context::Context::new(
@@ -602,11 +584,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             // Deserialize instruction.
                                             #deserialize_instruction
 
-                                            // Bump collector.
-                                            let mut __bumps = std::collections::BTreeMap::new();
-
-                                            // Realloc tracker.
-                                            let mut __reallocs= std::collections::BTreeSet::new();
+                                            let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                                             // Deserialize the program state account.
                                             let mut remaining_accounts: &[AccountInfo] = accounts;
@@ -617,8 +595,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                                 program_id,
                                                 &mut remaining_accounts,
                                                 &[],
-                                                &mut __bumps,
-                                                &mut __reallocs,
+                                                &mut __ctx,
                                             )?;
 
                                             // Deserialize accounts.
@@ -626,8 +603,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                                 program_id,
                                                 &mut remaining_accounts,
                                                 ix_data,
-                                                &mut __bumps,
-                                                &mut __reallocs,
+                                                &mut __ctx,
                                             )?;
                                             let ctx =
                                                 anchor_lang::context::Context::new(
@@ -669,10 +645,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             // Deserialize instruction.
                                             #deserialize_instruction
 
-                                            // Bump collector.
-                                            let mut __bumps = std::collections::BTreeMap::new();
-
-                                            let mut __reallocs = std::collections::BTreeSet::new();
+                                            let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                                             // Deserialize accounts.
                                             let mut remaining_accounts: &[AccountInfo] = accounts;
@@ -680,8 +653,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                                 program_id,
                                                 &mut remaining_accounts,
                                                 ix_data,
-                                                &mut __bumps,
-                                                &mut __reallocs,
+                                                &mut __ctx,
                                             )?;
 
                                             // Execute user defined function.
@@ -740,10 +712,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         .map_err(|_| anchor_lang::error::ErrorCode::InstructionDidNotDeserialize)?;
                     let instruction::#variant_arm = ix;
 
-                    // Bump collector.
-                    let mut __bumps = std::collections::BTreeMap::new();
-
-                    let mut __reallocs = std::collections::BTreeSet::new();
+                    let mut __ctx = anchor_lang::TryAccountsContext::default();
 
                     // Deserialize accounts.
                     let mut remaining_accounts: &[AccountInfo] = accounts;
@@ -751,8 +720,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         program_id,
                         &mut remaining_accounts,
                         ix_data,
-                        &mut __bumps,
-                        &mut __reallocs,
+                        &mut __ctx,
                     )?;
 
                     // Invoke user defined handler.

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -267,7 +267,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                         program_id,
                                         &mut ctor_user_def_accounts,
                                         remaining_accounts,
-                                        __bumps,
+                                        __ctx.bumps,
                                     ),
                                     #(#ctor_untyped_args),*
                                 )?;
@@ -309,7 +309,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                     program_id,
                                     &mut ctor_user_def_accounts,
                                     remaining_accounts,
-                                    __bumps,
+                                    __ctx.bumps,
                                 ),
                                 #(#ctor_untyped_args),*
                             )?;
@@ -423,7 +423,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             program_id,
                                             &mut accounts,
                                             remaining_accounts,
-                                            __bumps,
+                                            __ctx.bumps,
                                         );
 
                                     // Execute user defined function.
@@ -483,7 +483,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             program_id,
                                             &mut accounts,
                                             remaining_accounts,
-                                            __bumps
+                                            __ctx.bumps
                                         );
 
                                     // Execute user defined function.
@@ -610,7 +610,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                                     program_id,
                                                     &mut accounts,
                                                     remaining_accounts,
-                                                    __bumps,
+                                                    __ctx.bumps,
                                                 );
 
                                             // Execute user defined function.
@@ -662,7 +662,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                                     program_id,
                                                     &mut accounts,
                                                     remaining_accounts,
-                                                    __bumps
+                                                    __ctx.bumps
                                                 ),
                                                 #(#ix_arg_names),*
                                             )?;
@@ -729,7 +729,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                             program_id,
                             &mut accounts,
                             remaining_accounts,
-                            __bumps,
+                            __ctx.bumps,
                         ),
                         #(#ix_arg_names),*
                     )?;

--- a/lang/syn/src/parser/accounts/mod.rs
+++ b/lang/syn/src/parser/accounts/mod.rs
@@ -33,7 +33,7 @@ pub fn parse(strct: &syn::ItemStruct) -> ParseResult<AccountsStruct> {
         }
     };
 
-    let _ = constraints_cross_checks(&fields)?;
+    constraints_cross_checks(&fields)?;
 
     Ok(AccountsStruct::new(strct.clone(), fields, instruction_api))
 }

--- a/ts/src/error.ts
+++ b/ts/src/error.ts
@@ -366,6 +366,7 @@ export const LangErrorCode = {
   AccountSysvarMismatch: 3015,
   AccountReallocExceedsLimit: 3016,
   AccountDuplicateReallocs: 3017,
+  AccountDuplicateMutables: 3018,
 
   // State.
   StateInvalidAddress: 4000,
@@ -512,6 +513,10 @@ export const LangErrorMessage = new Map([
   [
     LangErrorCode.AccountDuplicateReallocs,
     "The account was duplicated for more than one reallocation",
+  ],
+  [
+    LangErrorCode.AccountDuplicateMutables,
+    "The account was duplicated in more than one mutable account info.",
   ],
 
   // State.


### PR DESCRIPTION
- adjust `Accounts::try_accounts` signature to be new `TryAccountsContext` to end breaking changes and house `bumps`, `reallocs`, and new `mutables` fields
- check if the same account public key has been marked as mutable more than once with new `BTreeSet` field in `TryAccountsContext`
- add new `AccountDuplicateMutables` error to `lang` and `ts`