### PR TITLE
Fixing breaking change where null or undefined wallet throws an error

### DIFF
--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -60,7 +60,7 @@ export class AnchorProvider implements Provider {
     readonly wallet: Wallet,
     readonly opts: ConfirmOptions
   ) {
-    this.publicKey = wallet.publicKey;
+    this.publicKey = wallet?.publicKey;
   }
 
   static defaultOptions(): ConfirmOptions {


### PR DESCRIPTION
Change introduced in https://github.com/coral-xyz/anchor/pull/1845
Intention from https://github.com/coral-xyz/anchor/pull/1867 is for optional publicKey