### PR TITLE
Allow custom dispatcher

### DIFF
--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -162,6 +162,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 }
             }
 
+            #[cfg(feature = "custom_dispatch")] if let Some(result) = custom_dispatch(sighash, program_id, accounts, &ix_data) {return result};
+
+
             match sighash {
                 #ctor_state_dispatch_arm
                 #(#state_dispatch_arms)*


### PR DESCRIPTION
**Context** 

When programs try to migrate to anchor a big blocker is the instruction dispatcher. If the code is in production and client code for sending instructions has been released and is being used, switching to the anchor dispatcher will break client code. 
Migrators currently have to :
- update their onchain programs to be compatible with both the anchor instruction discriminant and the previous instruction discriminant. 
- update their client code to use anchor discriminants and ask all their client-code consumers to upgrade.
- once enough consumers switch no need to support previous instruction discriminants, you can fully migrate to anchor.

During steps 1 and 2, migrators have to use their "custom" version of anchor or not anchor, making it harder and less secure.

 **This PR**

In this PR, we add the feature of adding a custom dispatcher. The anchor dispatcher will be called before the custom dispatcher, if no match is found. This guarantees that the IDL and the generated anchor client will work 100%. 
For programs that use a short instruction discriminator and user provided data, there's a collision risk where an instruction in the old format might end up going somewhere through the anchor dispatcher. However the probability should be small.
This advanced feature will be gated by the `custom_dispatch` flag that users will have to activate in their program.

**Limits** 
Note that this doesn't aim to solve account migration, but arguably this is a less important topic because anchor already supports the `AccountInfo` type of account, which allows anchor users to benefit from all the other features of anchors without having their accounts be the "anchor" way.
