### PR TITLE
spl: custom wrapped anchor type for mpl metadata account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 ### Features
 
 * client: Add `transaction` functions to RequestBuilder ([#1958](https://github.com/coral-xyz/anchor/pull/1958)).
+* spl: Add `MetadataAccount` wrapper for Metaplex metadata program accounts ([#2110](https://github.com/coral-xyz/anchor/pull/2110)).
 
 ## [0.25.0] - 2022-07-05
 

--- a/spl/src/metadata.rs
+++ b/spl/src/metadata.rs
@@ -1,9 +1,10 @@
 use anchor_lang::context::CpiContext;
-use anchor_lang::{Accounts, Result, ToAccountInfos};
+use anchor_lang::{Accounts, AnchorDeserialize, Result, ToAccountInfos};
 use mpl_token_metadata::state::DataV2;
 use mpl_token_metadata::ID;
 use solana_program::account_info::AccountInfo;
 use solana_program::pubkey::Pubkey;
+use std::ops::Deref;
 
 #[derive(Clone)]
 pub struct Metadata;
@@ -182,4 +183,35 @@ pub struct MintNewEditionFromMasterEditionViaToken<'info> {
     // helper pass in the `edition_mark_pda` directly.
     //
     pub metadata_mint: AccountInfo<'info>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MetadataAccount(mpl_token_metadata::state::Metadata);
+
+impl MetadataAccount {
+    pub const LEN: usize = mpl_token_metadata::state::MAX_METADATA_LEN;
+}
+
+impl anchor_lang::AccountDeserialize for MetadataAccount {
+    fn try_deserialize_unchecked(buf: &mut &[u8]) -> anchor_lang::Result<Self> {
+        mpl_token_metadata::state::Metadata::deserialize(buf)
+            .map(MetadataAccount)
+            .map_err(Into::into)
+    }
+}
+
+impl anchor_lang::AccountSerialize for MetadataAccount {}
+
+impl anchor_lang::Owner for MetadataAccount {
+    fn owner() -> Pubkey {
+        ID
+    }
+}
+
+impl Deref for MetadataAccount {
+    type Target = mpl_token_metadata::state::Metadata;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }


### PR DESCRIPTION
adds `anchor_spl::metadata::MetadataAccount` wrapper for the `mpl_token_metadata::state::Metadata` serializable account type.