### PR TITLE
Add option to sign tx with generic wallet interface

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -5,6 +5,7 @@ export { default as BN } from "bn.js";
 export * as web3 from "@solana/web3.js";
 export {
   default as Provider,
+  Wallet as WalletAdaptor,
   getProvider,
   setProvider,
   AnchorProvider,

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -28,16 +28,16 @@ export default interface Provider {
   ): Promise<TransactionSignature>;
   sendAndConfirm?(
     tx: Transaction,
-    signers?: Signer[],
+    signers?: (Signer | Wallet)[],
     opts?: ConfirmOptions
   ): Promise<TransactionSignature>;
   sendAll?(
-    txWithSigners: { tx: Transaction; signers?: Signer[] }[],
+    txWithSigners: { tx: Transaction; signers?: (Signer | Wallet)[] }[],
     opts?: ConfirmOptions
   ): Promise<Array<TransactionSignature>>;
   simulate?(
     tx: Transaction,
-    signers?: Signer[],
+    signers?: (Signer | Wallet)[],
     commitment?: Commitment,
     includeAccounts?: boolean | PublicKey[]
   ): Promise<SuccessfulTxSimulationResponse>;
@@ -116,6 +116,16 @@ export class AnchorProvider implements Provider {
     return new AnchorProvider(connection, wallet, options);
   }
 
+  async addSignatures(tx: Transaction, signers: (Signer | Wallet)[]) {
+    (signers ?? []).forEach(async (signer) => {
+      if (signer["publicKey"] != null && signer["secretKey"] != null) {
+        tx.partialSign(signer as Signer);
+      } else {
+        tx = await (signer as Wallet).signTransaction(tx);
+      }
+    });
+  }
+
   /**
    * Sends the given transaction, paid for and signed by the provider's wallet.
    *
@@ -125,7 +135,7 @@ export class AnchorProvider implements Provider {
    */
   async sendAndConfirm(
     tx: Transaction,
-    signers?: Signer[],
+    signers?: (Signer | Wallet)[],
     opts?: ConfirmOptions
   ): Promise<TransactionSignature> {
     if (opts === undefined) {
@@ -138,9 +148,9 @@ export class AnchorProvider implements Provider {
     ).blockhash;
 
     tx = await this.wallet.signTransaction(tx);
-    (signers ?? []).forEach((kp) => {
-      tx.partialSign(kp);
-    });
+    if (signers != null) {
+      await this.addSignatures(tx, signers);
+    }
 
     const rawTx = tx.serialize();
 
@@ -174,7 +184,7 @@ export class AnchorProvider implements Provider {
    * Similar to `send`, but for an array of transactions and signers.
    */
   async sendAll(
-    txWithSigners: { tx: Transaction; signers?: Signer[] }[],
+    txWithSigners: { tx: Transaction; signers?: (Signer | Wallet)[] }[],
     opts?: ConfirmOptions
   ): Promise<Array<TransactionSignature>> {
     if (opts === undefined) {
@@ -184,19 +194,20 @@ export class AnchorProvider implements Provider {
       opts.preflightCommitment
     );
 
-    let txs = txWithSigners.map((r) => {
-      let tx = r.tx;
-      let signers = r.signers ?? [];
+    let txs = await Promise.all(
+      txWithSigners.map(async (r): Promise<Transaction> => {
+        let tx = r.tx;
+        let signers = r.signers ?? [];
 
-      tx.feePayer = this.wallet.publicKey;
-      tx.recentBlockhash = blockhash.blockhash;
+        tx.feePayer = this.wallet.publicKey;
+        tx.recentBlockhash = blockhash.blockhash;
+        if (signers != null) {
+          await this.addSignatures(tx, signers);
+        }
 
-      signers.forEach((kp) => {
-        tx.partialSign(kp);
-      });
-
-      return tx;
-    });
+        return tx;
+      })
+    );
 
     const signedTxs = await this.wallet.signAllTransactions(txs);
 
@@ -222,7 +233,7 @@ export class AnchorProvider implements Provider {
    */
   async simulate(
     tx: Transaction,
-    signers?: Signer[],
+    signers?: (Signer | Wallet)[],
     commitment?: Commitment,
     includeAccounts?: boolean | PublicKey[]
   ): Promise<SuccessfulTxSimulationResponse> {

--- a/ts/src/utils/rpc.ts
+++ b/ts/src/utils/rpc.ts
@@ -121,12 +121,19 @@ async function getMultipleAccountsCore(
 export async function simulateTransaction(
   connection: Connection,
   transaction: Transaction,
-  signers?: Array<Signer>,
+  signers?: Array<Signer|Wallet>,
   commitment?: Commitment,
   includeAccounts?: boolean | Array<PublicKey>
 ): Promise<RpcResponseAndContext<SimulatedTransactionResponse>> {
   if (signers && signers.length > 0) {
-    transaction.sign(...signers);
+    (signers ?? []).forEach(async (signer) => {
+      if (signer["publicKey"] != null && signer["secretKey"] != null) {
+        transaction.partialSign(signer as Signer);
+      } else {
+        transaction = await (signer as Wallet).signTransaction(transaction);
+      }
+    });
+
   }
 
   // @ts-expect-error


### PR DESCRIPTION
Problem
Client SDK methods for sending transactions, e.g. `AnchorProvider.sendAndConfirm` and `sendAll`, only allowing transaction signing using `Signer` type. `Signer` type exposes both the public key and the private/secret key. 

This doesn't work for hardware wallets, which do not allow the secret key to be exposed.

Solution
Expose a generic wallet interface with methods `signTransaction` and `signAllTransactions`. Next, in methods like `AnchorProvider.sendAndConfirm` and `sendAll`, accept the generic wallet interface and use it to sign transactions.

Users are free to implement their own wallet interface for the hardware wallets (such as ledger).

Backward compatibility with existing interfaces is kept.
