### PR TITLE
Fix vec[defined] typedefs

### DIFF
--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -125,6 +125,8 @@ export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
   ? TypeMap[T["coption"]] | null
   : T extends { vec: keyof TypeMap }
   ? TypeMap[T["vec"]][]
+  : T extends { vec: { defined: keyof Defined } }
+  ? Defined[T["vec"]["defined"]][]
   : T extends { array: [defined: keyof TypeMap, size: number] }
   ? TypeMap[T["array"][0]][]
   : unknown;


### PR DESCRIPTION
Using a vector of a defined type will result in `unknown[]` due to a missing conditional branch for this case.

<details>
<summary>Example</summary>

```
types: [
    {
      name: "one";
      type: {
        kind: "struct";
        fields: [
          {
            name: "name";
            type: "string";
          }
        ];
      };
    },
    {
      name: "two";
      type: {
        kind: "struct";
        fields: [
          {
            name: "name";
            type: "string";
          },
          {
            name: "ones";
            type: {
              vec: {
                defined: "one";
              };
            };
          }
        ];
      };
    }
  ];
```
</details>