### PR TITLE
AccountClient narrow type to actual Account

### DIFF
--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -41,15 +41,6 @@ export default class AccountFactory {
   }
 }
 
-type NullableIdlAccount<
-  IDL extends Idl,
-  K extends keyof AllAccountsMap<IDL> | undefined = undefined
-> = IDL["accounts"] extends undefined
-  ? IdlAccountDef
-  : K extends undefined
-  ? NonNullable<IDL["accounts"]>[number]
-  : NonNullable<IDL["accounts"]>[number] & { name: K };
-
 /**
  * The namespace provides handles to an [[AccountClient]] object for each
  * account in a program.
@@ -73,13 +64,13 @@ type NullableIdlAccount<
 export type AccountNamespace<IDL extends Idl = Idl> = {
   [K in keyof AllAccountsMap<IDL>]: AccountClient<
     IDL,
-    NullableIdlAccount<IDL, K>
+    NonNullable<IDL["accounts"]>[number] & { name: K }
   >;
 };
 
 export class AccountClient<
   IDL extends Idl = Idl,
-  A extends IdlAccountDef = IdlAccountDef,
+  A extends IdlAccountDef = NonNullable<IDL["accounts"]>[number],
   T = TypeDef<A, IdlTypes<IDL>>
 > {
   /**


### PR DESCRIPTION
Right now the AccountClient captures a union of all Accounts in the IDL and uses this to type things like the return from `fetch`. It would be better if each AccountClient was 'aware' of the account it was fetching and could type hint against its definition from the IDL.

This PR makes a few (unfortunately backwards _incompatible_ changes) to accomplish this.