### PR TITLE
ts: Fixed `.fetchNullable()` to be robust towards accounts only holding a balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The minor version will be incremented upon a breaking change and the patch versi
 * ts: Add `has_one` relations inference so accounts mapped via has_one relationships no longer need to be provided
 * ts: Add ability to set args after setting accounts and retriving pubkyes
 * ts: Add `.prepare()` to builder pattern
+* ts: Fixed `.fetchNullable()` to be robust towards accounts only holding a balance ([#2172](https://github.com/coral-xyz/anchor/pull/2172)).
 * spl: Add `freeze_delegated_account` and `thaw_delegated_account` wrappers ([#2164](https://github.com/coral-xyz/anchor/pull/2164))
 
 ### Fixes

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -636,6 +636,20 @@ describe("misc", () => {
     assert.strictEqual(account2.idata.toNumber(), 3);
   });
 
+  it("Can use fetchNullable() on accounts with only a balance", async () => {
+    const account = anchor.web3.Keypair.generate();
+
+    // Airdrop 1 SOL to the account.
+    const signature = await program.provider.connection.requestAirdrop(
+      account.publicKey,
+      anchor.web3.LAMPORTS_PER_SOL
+    );
+    await program.provider.connection.confirmTransaction(signature);
+
+    const data = await program.account.data.fetchNullable(account.publicKey);
+    assert.isNull(data);
+  });
+
   describe("associated_token constraints", () => {
     let associatedToken = null;
     // apparently cannot await here so doing it in the 'it' statements

--- a/ts/packages/anchor/src/program/namespace/account.ts
+++ b/ts/packages/anchor/src/program/namespace/account.ts
@@ -134,7 +134,7 @@ export class AccountClient<
     commitment?: Commitment
   ): Promise<T | null> {
     const accountInfo = await this.getAccountInfo(address, commitment);
-    if (accountInfo === null) {
+    if (accountInfo === null || accountInfo.data.length === 0) {
       return null;
     }
     return this._coder.accounts.decode<T>(
@@ -151,7 +151,7 @@ export class AccountClient<
   async fetch(address: Address, commitment?: Commitment): Promise<T> {
     const data = await this.fetchNullable(address, commitment);
     if (data === null) {
-      throw new Error(`Account does not exist ${address.toString()}`);
+      throw new Error(`Account does not exist or has no data ${address.toString()}`);
     }
     return data;
   }


### PR DESCRIPTION
Fix for #2172.

Using fetchNullable() on accounts with a balance caused an unexpected exception.
```
       Can use fetchNullable() on accounts with only a balance:
     Error: Invalid account discriminator
      at BorshAccountsCoder.decode (/Users/mriedel/Development/identity-com/anchor/tests/node_modules/@project-serum/anchor/src/coder/borsh/accounts.ts:61:13)
      at AccountClient.fetchNullable (/Users/mriedel/Development/identity-com/anchor/tests/node_modules/@project-serum/anchor/src/program/namespace/account.ts:140:33)
```

Made `fetchNullable()` more robust to tolerate accounts with NO data. Added test in `misc`