### PR TITLE
feat: add support for tuple enum variants in typescript Idl parsing

### DIFF
--- a/ts/packages/anchor/src/coder/borsh/idl.ts
+++ b/ts/packages/anchor/src/coder/borsh/idl.ts
@@ -129,9 +129,14 @@ export class IdlCoder {
         if (variant.fields === undefined) {
           return borsh.struct([], name);
         }
-        const fieldLayouts = variant.fields.map((f: IdlField | IdlType) => {
+        const fieldLayouts = variant.fields.map((f: IdlField | IdlType, index: number) => {
           if (!f.hasOwnProperty("name")) {
-            throw new Error("Tuple enum variants not yet implemented.");
+            // Name tuple variants by the argument index
+            // e.g. arg0, arg1, arg2, etc
+            return IdlCoder.fieldLayout({
+              name: `arg${index}`,
+              type: f as IdlType
+            }, types);
           }
           // this typescript conversion is ok
           // because if f were of type IdlType

--- a/ts/packages/anchor/tests/coder-types.spec.ts
+++ b/ts/packages/anchor/tests/coder-types.spec.ts
@@ -1,5 +1,8 @@
 import * as assert from "assert";
-import { BorshCoder } from "../src";
+import { BorshCoder, Idl, BN } from "../src";
+// import {}
+
+import SplGov from '../idl.json';
 
 describe("coder.types", () => {
   test("Can encode and decode user-defined types", () => {
@@ -42,4 +45,46 @@ describe("coder.types", () => {
 
     assert.deepEqual(coder.types.decode("MintInfo", encoded), mintInfo);
   });
+  it("Test tuple enum variant decoding", () => {
+    const idl = {
+      version: "0.0.0",
+      name: "basic_0",
+      instructions: [
+        {
+          name: "initialize",
+          accounts: [],
+          args: [],
+        },
+      ],
+      types: [
+        {
+          name: "Vote",
+          type: {
+            kind: "enum" as const,
+            variants: [
+              {
+                name: "VoteWithComment",
+                fields: [
+                  "bool" as const,
+                  "string" as const,
+                ]
+              }
+            ]
+          }
+        },
+      ],
+    };
+    const coder = new BorshCoder(idl);
+
+    let vote = {
+      voteWithComment: {
+        arg0: true,
+        arg1: "blessed"
+      }
+    };
+    let encoded = coder.types.encode("Vote", vote);
+
+    assert.deepEqual(coder.types.decode("Vote", encoded), vote);
+  })
 });
+


### PR DESCRIPTION
Add support for enum Idl Types with tuple data like:
```rust
#[derive(AnchorSerialize, AnchorDeserialize)]
enum Vote {
  VoteWithComment(u8, String)
}
```
which has an idl representation of
```typescript
{
  name: "Vote",
  type: {
    kind: "enum",
    variants: [
      {
        name: "VoteWithComment",
        fields: [
          "bool",
          "string",
        ]
      }
    ]
  }
}
```
          