### PR TITLE
Add isReactNative check to support react-native

### DIFF
--- a/ts/packages/anchor/rollup.config.ts
+++ b/ts/packages/anchor/rollup.config.ts
@@ -5,6 +5,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import { terser } from "rollup-plugin-terser";
 
 const env = process.env.NODE_ENV;
+const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
 
 export default {
   input: "src/index.ts",
@@ -30,8 +31,9 @@ export default {
         "process.env.ANCHOR_BROWSER": JSON.stringify(true),
       },
     }),
-    terser(),
-  ],
+  ].concat(
+    isReactNative ? [] : [terser()]
+  ),
   external: [
     "@project-serum/borsh",
     "@solana/web3.js",

--- a/ts/packages/anchor/src/provider.ts
+++ b/ts/packages/anchor/src/provider.ts
@@ -11,7 +11,7 @@ import {
   SendOptions,
 } from "@solana/web3.js";
 import { bs58 } from "./utils/bytes/index.js";
-import { isBrowser } from "./utils/common.js";
+import { isBrowser, isReactNative } from "./utils/common.js";
 import {
   simulateTransaction,
   SuccessfulTxSimulationResponse,
@@ -79,7 +79,7 @@ export class AnchorProvider implements Provider {
    * (This api is for Node only.)
    */
   static local(url?: string, opts?: ConfirmOptions): AnchorProvider {
-    if (isBrowser) {
+    if (isBrowser && !isReactNative) {
       throw new Error(`Provider local is not available on browser.`);
     }
     opts = opts ?? AnchorProvider.defaultOptions();
@@ -99,7 +99,7 @@ export class AnchorProvider implements Provider {
    * (This api is for Node only.)
    */
   static env(): AnchorProvider {
-    if (isBrowser) {
+    if (isBrowser && !isReactNative) {
       throw new Error(`Provider env is not available on browser.`);
     }
 

--- a/ts/packages/anchor/src/utils/common.ts
+++ b/ts/packages/anchor/src/utils/common.ts
@@ -7,6 +7,12 @@ export const isBrowser =
   (typeof window !== "undefined" && !window.process?.hasOwnProperty("type"));
 
 /**
+ * Returns true if it is a react-native app,
+ * false if it not a react-native app.
+ */
+export const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative'
+
+/**
  * Splits an array into chunks
  *
  * @param array Array of objects to chunk.

--- a/ts/packages/anchor/src/workspace.ts
+++ b/ts/packages/anchor/src/workspace.ts
@@ -3,7 +3,7 @@ import * as toml from "toml";
 import { PublicKey } from "@solana/web3.js";
 import { Program } from "./program/index.js";
 import { Idl } from "./idl.js";
-import { isBrowser } from "./utils/common.js";
+import { isBrowser, isReactNative } from "./utils/common.js";
 
 let _populatedWorkspace = false;
 
@@ -16,7 +16,7 @@ let _populatedWorkspace = false;
  */
 const workspace = new Proxy({} as any, {
   get(workspaceCache: { [key: string]: Program }, programName: string) {
-    if (isBrowser) {
+    if (isBrowser && !isReactNative) {
       throw new Error("Workspaces aren't available in the browser");
     }
 


### PR DESCRIPTION
My approach is similar to https://github.com/coral-xyz/anchor/pull/2263#issue-1451869344.
But in my case, anchor also throw error: `Provider local is not available on browser.` that it detect my react-native project as a browser, so I also added `!isReactNative` there