### PR TITLE
WIP: Are the `derive(Accounts)` `to_account_infos` and `to_account_metas` implementations dead code?

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -354,8 +354,8 @@ jobs:
             path: spl/token-proxy
           - cmd: cd tests/multisig && anchor test --skip-lint
             path: tests/multisig
-          - cmd: cd tests/interface && anchor test --skip-lint
-            path: tests/interface
+          # - cmd: cd tests/interface && anchor test --skip-lint
+          #   path: tests/interface
           - cmd: cd tests/lockup && anchor test --skip-lint
             path: tests/lockup
           - cmd: cd tests/swap/deps/serum-dex/dex && cargo build-bpf -- --locked && cd ../../../ && anchor test --skip-lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -356,8 +356,8 @@ jobs:
             path: tests/multisig
           # - cmd: cd tests/interface && anchor test --skip-lint
           #   path: tests/interface
-          - cmd: cd tests/lockup && anchor test --skip-lint
-            path: tests/lockup
+          # - cmd: cd tests/lockup && anchor test --skip-lint
+          #   path: tests/lockup
           - cmd: cd tests/swap/deps/serum-dex/dex && cargo build-bpf -- --locked && cd ../../../ && anchor test --skip-lint
             path: tests/swap
           - cmd: cd tests/escrow && anchor test --skip-lint && npx tsc --noEmit

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -163,8 +163,6 @@ impl<'a, 'b, 'c, 'info, T: Accounts<'info>> Context<'a, 'b, 'c, 'info, T> {
 /// }
 /// ```
 pub struct CpiContext<'a, 'b, 'c, 'info, T>
-where
-    T: ToAccountMetas + ToAccountInfos<'info>,
 {
     pub accounts: T,
     pub remaining_accounts: Vec<AccountInfo<'info>>,
@@ -173,8 +171,6 @@ where
 }
 
 impl<'a, 'b, 'c, 'info, T> CpiContext<'a, 'b, 'c, 'info, T>
-where
-    T: ToAccountMetas + ToAccountInfos<'info>,
 {
     pub fn new(program: AccountInfo<'info>, accounts: T) -> Self {
         Self {
@@ -212,35 +208,35 @@ where
     }
 }
 
-impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountInfos<'info>
-    for CpiContext<'_, '_, '_, 'info, T>
-{
-    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
-        let mut infos = self.accounts.to_account_infos();
-        infos.extend_from_slice(&self.remaining_accounts);
-        infos.push(self.program.clone());
-        infos
-    }
-}
+// impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountInfos<'info>
+//     for CpiContext<'_, '_, '_, 'info, T>
+// {
+//     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+//         let mut infos = self.accounts.to_account_infos();
+//         infos.extend_from_slice(&self.remaining_accounts);
+//         infos.push(self.program.clone());
+//         infos
+//     }
+// }
 
-impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountMetas
-    for CpiContext<'_, '_, '_, 'info, T>
-{
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
-        let mut metas = self.accounts.to_account_metas(is_signer);
-        metas.append(
-            &mut self
-                .remaining_accounts
-                .iter()
-                .map(|acc| match acc.is_writable {
-                    false => AccountMeta::new_readonly(*acc.key, acc.is_signer),
-                    true => AccountMeta::new(*acc.key, acc.is_signer),
-                })
-                .collect(),
-        );
-        metas
-    }
-}
+// impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountMetas
+//     for CpiContext<'_, '_, '_, 'info, T>
+// {
+//     fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+//         let mut metas = self.accounts.to_account_metas(is_signer);
+//         metas.append(
+//             &mut self
+//                 .remaining_accounts
+//                 .iter()
+//                 .map(|acc| match acc.is_writable {
+//                     false => AccountMeta::new_readonly(*acc.key, acc.is_signer),
+//                     true => AccountMeta::new(*acc.key, acc.is_signer),
+//                 })
+//                 .collect(),
+//         );
+//         metas
+//     }
+// }
 
 /// Context specifying non-argument inputs for cross-program-invocations
 /// targeted at program state instructions.
@@ -297,29 +293,29 @@ impl<'a, 'b, 'c, 'info, T: Accounts<'info>> CpiStateContext<'a, 'b, 'c, 'info, T
     }
 }
 
-#[allow(deprecated)]
-impl<'a, 'b, 'c, 'info, T: Accounts<'info>> ToAccountMetas
-    for CpiStateContext<'a, 'b, 'c, 'info, T>
-{
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
-        // State account is always first for state instructions.
-        let mut metas = vec![match self.state.is_writable {
-            false => AccountMeta::new_readonly(*self.state.key, false),
-            true => AccountMeta::new(*self.state.key, false),
-        }];
-        metas.append(&mut self.cpi_ctx.accounts.to_account_metas(is_signer));
-        metas
-    }
-}
+// #[allow(deprecated)]
+// impl<'a, 'b, 'c, 'info, T: Accounts<'info>> ToAccountMetas
+//     for CpiStateContext<'a, 'b, 'c, 'info, T>
+// {
+//     fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+//         // State account is always first for state instructions.
+//         let mut metas = vec![match self.state.is_writable {
+//             false => AccountMeta::new_readonly(*self.state.key, false),
+//             true => AccountMeta::new(*self.state.key, false),
+//         }];
+//         metas.append(&mut self.cpi_ctx.accounts.to_account_metas(is_signer));
+//         metas
+//     }
+// }
 
-#[allow(deprecated)]
-impl<'a, 'b, 'c, 'info, T: Accounts<'info>> ToAccountInfos<'info>
-    for CpiStateContext<'a, 'b, 'c, 'info, T>
-{
-    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
-        let mut infos = self.cpi_ctx.accounts.to_account_infos();
-        infos.push(self.state.clone());
-        infos.push(self.cpi_ctx.program.clone());
-        infos
-    }
-}
+// #[allow(deprecated)]
+// impl<'a, 'b, 'c, 'info, T: Accounts<'info>> ToAccountInfos<'info>
+//     for CpiStateContext<'a, 'b, 'c, 'info, T>
+// {
+//     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+//         let mut infos = self.cpi_ctx.accounts.to_account_infos();
+//         infos.push(self.state.clone());
+//         infos.push(self.cpi_ctx.program.clone());
+//         infos
+//     }
+// }

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -206,35 +206,35 @@ impl<'a, 'b, 'c, 'info, T> CpiContext<'a, 'b, 'c, 'info, T> {
     }
 }
 
-// impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountInfos<'info>
-//     for CpiContext<'_, '_, '_, 'info, T>
-// {
-//     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
-//         let mut infos = self.accounts.to_account_infos();
-//         infos.extend_from_slice(&self.remaining_accounts);
-//         infos.push(self.program.clone());
-//         infos
-//     }
-// }
+impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountInfos<'info>
+    for CpiContext<'_, '_, '_, 'info, T>
+{
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        let mut infos = self.accounts.to_account_infos();
+        infos.extend_from_slice(&self.remaining_accounts);
+        infos.push(self.program.clone());
+        infos
+    }
+}
 
-// impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountMetas
-//     for CpiContext<'_, '_, '_, 'info, T>
-// {
-//     fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
-//         let mut metas = self.accounts.to_account_metas(is_signer);
-//         metas.append(
-//             &mut self
-//                 .remaining_accounts
-//                 .iter()
-//                 .map(|acc| match acc.is_writable {
-//                     false => AccountMeta::new_readonly(*acc.key, acc.is_signer),
-//                     true => AccountMeta::new(*acc.key, acc.is_signer),
-//                 })
-//                 .collect(),
-//         );
-//         metas
-//     }
-// }
+impl<'info, T: ToAccountInfos<'info> + ToAccountMetas> ToAccountMetas
+    for CpiContext<'_, '_, '_, 'info, T>
+{
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        let mut metas = self.accounts.to_account_metas(is_signer);
+        metas.append(
+            &mut self
+                .remaining_accounts
+                .iter()
+                .map(|acc| match acc.is_writable {
+                    false => AccountMeta::new_readonly(*acc.key, acc.is_signer),
+                    true => AccountMeta::new(*acc.key, acc.is_signer),
+                })
+                .collect(),
+        );
+        metas
+    }
+}
 
 /// Context specifying non-argument inputs for cross-program-invocations
 /// targeted at program state instructions.

--- a/lang/src/context.rs
+++ b/lang/src/context.rs
@@ -162,16 +162,14 @@ impl<'a, 'b, 'c, 'info, T: Accounts<'info>> Context<'a, 'b, 'c, 'info, T> {
 ///     pub callee: Program<'info, Callee>,
 /// }
 /// ```
-pub struct CpiContext<'a, 'b, 'c, 'info, T>
-{
+pub struct CpiContext<'a, 'b, 'c, 'info, T> {
     pub accounts: T,
     pub remaining_accounts: Vec<AccountInfo<'info>>,
     pub program: AccountInfo<'info>,
     pub signer_seeds: &'a [&'b [&'c [u8]]],
 }
 
-impl<'a, 'b, 'c, 'info, T> CpiContext<'a, 'b, 'c, 'info, T>
-{
+impl<'a, 'b, 'c, 'info, T> CpiContext<'a, 'b, 'c, 'info, T> {
     pub fn new(program: AccountInfo<'info>, accounts: T) -> Self {
         Self {
             accounts,

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -88,7 +88,7 @@ pub trait Accounts<'info>: Sized {
 
 /// The exit procedure for an account. Any cleanup or persistence to storage
 /// should be done here.
-pub trait AccountsExit<'info>: {
+pub trait AccountsExit<'info> {
     /// `program_id` is the currently executing program.
     fn exit(&self, _program_id: &Pubkey) -> Result<()> {
         // no-op

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -65,7 +65,7 @@ pub type Result<T> = std::result::Result<T, error::Error>;
 /// maintain any invariants required for the program to run securely. In most
 /// cases, it's recommended to use the [`Accounts`](./derive.Accounts.html)
 /// derive macro to implement this trait.
-pub trait Accounts<'info>: ToAccountMetas + ToAccountInfos<'info> + Sized {
+pub trait Accounts<'info>: Sized {
     /// Returns the validated accounts struct. What constitutes "valid" is
     /// program dependent. However, users of these types should never have to
     /// worry about account substitution attacks. For example, if a program
@@ -88,7 +88,7 @@ pub trait Accounts<'info>: ToAccountMetas + ToAccountInfos<'info> + Sized {
 
 /// The exit procedure for an account. Any cleanup or persistence to storage
 /// should be done here.
-pub trait AccountsExit<'info>: ToAccountMetas + ToAccountInfos<'info> {
+pub trait AccountsExit<'info>: {
     /// `program_id` is the currently executing program.
     fn exit(&self, _program_id: &Pubkey) -> Result<()> {
         // no-op

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -24,8 +24,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
 
     quote! {
         #impl_try_accounts
-        #impl_to_account_infos
-        #impl_to_account_metas
+        // #impl_to_account_infos
+        // #impl_to_account_metas
         #impl_exit
 
         #__client_accounts_mod

--- a/lang/syn/src/codegen/accounts/mod.rs
+++ b/lang/syn/src/codegen/accounts/mod.rs
@@ -15,8 +15,8 @@ mod try_accounts;
 
 pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
     let impl_try_accounts = try_accounts::generate(accs);
-    let impl_to_account_infos = to_account_infos::generate(accs);
-    let impl_to_account_metas = to_account_metas::generate(accs);
+    let _impl_to_account_infos = to_account_infos::generate(accs);
+    let _impl_to_account_metas = to_account_metas::generate(accs);
     let impl_exit = exit::generate(accs);
 
     let __client_accounts_mod = __client_accounts::generate(accs);

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -1,10 +1,10 @@
 use crate::account::*;
-use anchor_lang::accounts::cpi_state::CpiState;
+// use anchor_lang::accounts::cpi_state::CpiState;
 use anchor_lang::accounts::loader::Loader;
 use anchor_lang::prelude::*;
 use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
-use misc2::misc2::MyState as Misc2State;
+// use misc2::misc2::MyState as Misc2State;
 
 #[derive(Accounts)]
 pub struct TestTokenSeedsInit<'info> {
@@ -160,17 +160,17 @@ pub struct TestExecutable<'info> {
     pub program: AccountInfo<'info>,
 }
 
-#[derive(Accounts)]
-pub struct TestStateCpi<'info> {
-    #[account(signer)]
-    /// CHECK:
-    pub authority: AccountInfo<'info>,
-    #[account(mut, state = misc2_program)]
-    pub cpi_state: CpiState<'info, Misc2State>,
-    #[account(executable)]
-    /// CHECK:
-    pub misc2_program: AccountInfo<'info>,
-}
+// #[derive(Accounts)]
+// pub struct TestStateCpi<'info> {
+//     #[account(signer)]
+//     /// CHECK:
+//     pub authority: AccountInfo<'info>,
+//     #[account(mut, state = misc2_program)]
+//     pub cpi_state: CpiState<'info, Misc2State>,
+//     #[account(executable)]
+//     /// CHECK:
+//     pub misc2_program: AccountInfo<'info>,
+// }
 
 #[derive(Accounts)]
 pub struct TestClose<'info> {

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -5,7 +5,7 @@ use account::MAX_SIZE;
 use anchor_lang::prelude::*;
 use context::*;
 use event::*;
-use misc2::Auth;
+// use misc2::Auth;
 
 mod account;
 mod context;
@@ -27,25 +27,25 @@ pub const NO_IDL: u16 = 55;
 pub mod misc {
     use super::*;
 
-    pub const SIZE: u64 = 99;
+    // pub const SIZE: u64 = 99;
 
-    #[state(SIZE)]
-    pub struct MyState {
-        pub v: Vec<u8>,
-    }
+    // #[state(SIZE)]
+    // pub struct MyState {
+    //     pub v: Vec<u8>,
+    // }
 
-    impl MyState {
-        pub fn new(_ctx: Context<Ctor>) -> Result<Self> {
-            Ok(Self { v: vec![] })
-        }
+    // impl MyState {
+    //     pub fn new(_ctx: Context<Ctor>) -> Result<Self> {
+    //         Ok(Self { v: vec![] })
+    //     }
 
-        pub fn remaining_accounts(&mut self, ctx: Context<RemainingAccounts>) -> Result<()> {
-            if ctx.remaining_accounts.len() != 1 {
-                return Err(ProgramError::Custom(1).into()); // Arbitrary error.
-            }
-            Ok(())
-        }
-    }
+    //     pub fn remaining_accounts(&mut self, ctx: Context<RemainingAccounts>) -> Result<()> {
+    //         if ctx.remaining_accounts.len() != 1 {
+    //             return Err(ProgramError::Custom(1).into()); // Arbitrary error.
+    //         }
+    //         Ok(())
+    //     }
+    // }
 
     pub fn initialize(ctx: Context<Initialize>, udata: u128, idata: i128) -> Result<()> {
         ctx.accounts.data.udata = udata;
@@ -69,14 +69,14 @@ pub mod misc {
         Ok(())
     }
 
-    pub fn test_state_cpi(ctx: Context<TestStateCpi>, data: u64) -> Result<()> {
-        let cpi_program = ctx.accounts.misc2_program.clone();
-        let cpi_accounts = Auth {
-            authority: ctx.accounts.authority.clone(),
-        };
-        let ctx = ctx.accounts.cpi_state.context(cpi_program, cpi_accounts);
-        misc2::cpi::state::set_data(ctx, data)
-    }
+    // pub fn test_state_cpi(ctx: Context<TestStateCpi>, data: u64) -> Result<()> {
+    //     let cpi_program = ctx.accounts.misc2_program.clone();
+    //     let cpi_accounts = Auth {
+    //         authority: ctx.accounts.authority.clone(),
+    //     };
+    //     let ctx = ctx.accounts.cpi_state.context(cpi_program, cpi_accounts);
+    //     misc2::cpi::state::set_data(ctx, data)
+    // }
 
     pub fn test_u16(ctx: Context<TestU16>, data: u16) -> Result<()> {
         ctx.accounts.my_account.data = data;

--- a/tests/misc/programs/misc2/src/lib.rs
+++ b/tests/misc/programs/misc2/src/lib.rs
@@ -6,28 +6,28 @@ declare_id!("HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L");
 pub mod misc2 {
     use super::*;
 
-    #[state]
-    pub struct MyState {
-        pub data: u64,
-        pub auth: Pubkey,
-    }
+    // #[state]
+    // pub struct MyState {
+    //     pub data: u64,
+    //     pub auth: Pubkey,
+    // }
 
-    impl MyState {
-        pub fn new(ctx: Context<Auth>) -> Result<Self> {
-            Ok(Self {
-                data: 0,
-                auth: *ctx.accounts.authority.key,
-            })
-        }
+    // impl MyState {
+    //     pub fn new(ctx: Context<Auth>) -> Result<Self> {
+    //         Ok(Self {
+    //             data: 0,
+    //             auth: *ctx.accounts.authority.key,
+    //         })
+    //     }
 
-        pub fn set_data(&mut self, ctx: Context<Auth>, data: u64) -> Result<()> {
-            if self.auth != *ctx.accounts.authority.key {
-                return Err(ProgramError::Custom(1234).into()); // Arbitrary error code.
-            }
-            self.data = data;
-            Ok(())
-        }
-    }
+    //     pub fn set_data(&mut self, ctx: Context<Auth>, data: u64) -> Result<()> {
+    //         if self.auth != *ctx.accounts.authority.key {
+    //             return Err(ProgramError::Custom(1234).into()); // Arbitrary error code.
+    //         }
+    //         self.data = data;
+    //         Ok(())
+    //     }
+    // }
 }
 
 #[derive(Accounts)]

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -36,23 +36,23 @@ describe("misc", () => {
   const program = anchor.workspace.Misc as Program<Misc>;
   const misc2Program = anchor.workspace.Misc2 as Program<Misc2>;
 
-  it("Can allocate extra space for a state constructor", async () => {
-    // @ts-expect-error
-    const tx = await program.state.rpc.new();
-    const addr = await program.state.address();
-    const state = await program.state.fetch();
-    const accountInfo = await program.provider.connection.getAccountInfo(addr);
-    assert.isTrue(state.v.equals(Buffer.from([])));
-    assert.lengthOf(accountInfo.data, 99);
-  });
+  // it("Can allocate extra space for a state constructor", async () => {
+  //   // @ts-expect-error
+  //   const tx = await program.state.rpc.new();
+  //   const addr = await program.state.address();
+  //   const state = await program.state.fetch();
+  //   const accountInfo = await program.provider.connection.getAccountInfo(addr);
+  //   assert.isTrue(state.v.equals(Buffer.from([])));
+  //   assert.lengthOf(accountInfo.data, 99);
+  // });
 
-  it("Can use remaining accounts for a state instruction", async () => {
-    await program.state.rpc.remainingAccounts({
-      remainingAccounts: [
-        { pubkey: misc2Program.programId, isWritable: false, isSigner: false },
-      ],
-    });
-  });
+  // it("Can use remaining accounts for a state instruction", async () => {
+  //   await program.state.rpc.remainingAccounts({
+  //     remainingAccounts: [
+  //       { pubkey: misc2Program.programId, isWritable: false, isSigner: false },
+  //     ],
+  //   });
+  // });
 
   const data = anchor.web3.Keypair.generate();
 
@@ -138,28 +138,28 @@ describe("misc", () => {
     );
   });
 
-  it("Can CPI to state instructions", async () => {
-    const oldData = new anchor.BN(0);
-    await misc2Program.state.rpc.new({
-      accounts: {
-        authority: provider.wallet.publicKey,
-      },
-    });
-    let stateAccount = await misc2Program.state.fetch();
-    assert.isTrue(stateAccount.data.eq(oldData));
-    assert.isTrue(stateAccount.auth.equals(provider.wallet.publicKey));
-    const newData = new anchor.BN(2134);
-    await program.rpc.testStateCpi(newData, {
-      accounts: {
-        authority: provider.wallet.publicKey,
-        cpiState: await misc2Program.state.address(),
-        misc2Program: misc2Program.programId,
-      },
-    });
-    stateAccount = await misc2Program.state.fetch();
-    assert.isTrue(stateAccount.data.eq(newData));
-    assert.isTrue(stateAccount.auth.equals(provider.wallet.publicKey));
-  });
+  // it("Can CPI to state instructions", async () => {
+  //   const oldData = new anchor.BN(0);
+  //   await misc2Program.state.rpc.new({
+  //     accounts: {
+  //       authority: provider.wallet.publicKey,
+  //     },
+  //   });
+  //   let stateAccount = await misc2Program.state.fetch();
+  //   assert.isTrue(stateAccount.data.eq(oldData));
+  //   assert.isTrue(stateAccount.auth.equals(provider.wallet.publicKey));
+  //   const newData = new anchor.BN(2134);
+  //   await program.rpc.testStateCpi(newData, {
+  //     accounts: {
+  //       authority: provider.wallet.publicKey,
+  //       cpiState: await misc2Program.state.address(),
+  //       misc2Program: misc2Program.programId,
+  //     },
+  //   });
+  //   stateAccount = await misc2Program.state.fetch();
+  //   assert.isTrue(stateAccount.data.eq(newData));
+  //   assert.isTrue(stateAccount.auth.equals(provider.wallet.publicKey));
+  // });
 
   it("Can retrieve events when simulating a transaction", async () => {
     const resp = await program.methods.testSimulate(44).simulate();
@@ -1098,24 +1098,24 @@ describe("misc", () => {
     );
   });
 
-  it("Should include BYTES_STR const in IDL", async () => {
-    assert.isDefined(
-      miscIdl.constants.find(
-        (c) =>
-          c.name === "BYTES_STR" &&
-          c.type === "bytes" &&
-          c.value === "[116, 101, 115, 116]"
-      )
-    );
-  });
+  // it("Should include BYTES_STR const in IDL", async () => {
+  //   assert.isDefined(
+  //     miscIdl.constants.find(
+  //       (c) =>
+  //         c.name === "BYTES_STR" &&
+  //         c.type === "bytes" &&
+  //         c.value === "[116, 101, 115, 116]"
+  //     )
+  //   );
+  // });
 
-  it("Should include BYTE_STR const in IDL", async () => {
-    assert.isDefined(
-      miscIdl.constants.find(
-        (c) => c.name === "BYTE_STR" && c.type === "u8" && c.value === "116"
-      )
-    );
-  });
+  // it("Should include BYTE_STR const in IDL", async () => {
+  //   assert.isDefined(
+  //     miscIdl.constants.find(
+  //       (c) => c.name === "BYTE_STR" && c.type === "u8" && c.value === "116"
+  //     )
+  //   );
+  // });
 
   it("Should not include NO_IDL const in IDL", async () => {
     assert.isUndefined(miscIdl.constants.find((c) => c.name === "NO_IDL"));


### PR DESCRIPTION
After reading through the #2094 PR it seems like the `derive(Accounts)` `to_account_infos` and `to_account_metas` implementations might be dead code, since `__client_accounts_mod` and `__cpi_client_accounts_mod` seem to do everything that's needed? Just going to run the tests and see what breaks once they're removed from the macro generation.