### PR TITLE
Missing clippy ignore lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-large-error-threshold = 1_000_000
+# 

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+large-error-threshold = 1_000_000

--- a/.github/workflows/no-cashing-tests.yaml
+++ b/.github/workflows/no-cashing-tests.yaml
@@ -21,10 +21,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: cargo build
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings -A clippy::result-large-err
+      - run: cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings && cargo test -- --test-threads=1
+      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err && cargo test -- --test-threads=1
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint

--- a/.github/workflows/no-cashing-tests.yaml
+++ b/.github/workflows/no-cashing-tests.yaml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: cargo build
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings -A clippy::result-large-err
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
       - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings && cargo test -- --test-threads=1

--- a/.github/workflows/no-cashing-tests.yaml
+++ b/.github/workflows/no-cashing-tests.yaml
@@ -21,10 +21,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
       - run: cargo build
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err
+      - run: cargo clippy --all-targets -- -D warnings -A clippy::result-large-err
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err && cargo test -- --test-threads=1
+      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -A clippy::result-large-err && cargo test -- --test-threads=1
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,10 +36,10 @@ jobs:
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -A clippy::result-large-err && cargo test -- --test-threads=1
+      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err && cargo test -- --test-threads=1
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,10 +36,10 @@ jobs:
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err
+      - run: cargo clippy --all-targets -- -D warnings -A clippy::result-large-err
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -- -A clippy::result-large-err && cargo test -- --test-threads=1
+      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -A clippy::result-large-err && cargo test -- --test-threads=1
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
           key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build
       - run: cargo fmt -- --check
-      - run: cargo clippy --all-targets -- -D warnings -A clippy::result-large-err
+      - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
       - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -A clippy::result-large-err && cargo test -- --test-threads=1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings && cargo test -- --test-threads=1
+      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -A clippy::result-large-err && cargo test -- --test-threads=1
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo test
       # using singlethreaded testing for avm so that tests that change files do not conflict with each other
-      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings -A clippy::result-large-err && cargo test -- --test-threads=1
+      - run: cd avm && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings && cargo test -- --test-threads=1
       - run: cd ts/packages/anchor && yarn --frozen-lockfile
       - run: cd ts/packages/anchor && yarn test
       - run: cd ts/packages/anchor && yarn lint


### PR DESCRIPTION
Now core tests are failing because this lint skipper got lost somewhere along the way.