### PR TITLE
Deprecate decoding msg! events to improve errorOnDecodeFailure event parsing.

### DIFF
--- a/ts/packages/anchor/src/program/event.ts
+++ b/ts/packages/anchor/src/program/event.ts
@@ -5,9 +5,7 @@ import { Coder } from "../coder/index.js";
 import { DecodeType } from "./namespace/types.js";
 import Provider from "../provider.js";
 
-const PROGRAM_LOG = "Program log: ";
 const PROGRAM_DATA = "Program data: ";
-const PROGRAM_LOG_START_INDEX = PROGRAM_LOG.length;
 const PROGRAM_DATA_START_INDEX = PROGRAM_DATA.length;
 
 // Deserialized event.
@@ -226,11 +224,9 @@ export class EventParser {
     log: string,
     errorOnDecodeFailure: boolean
   ): [Event | null, string | null, boolean] {
-    // This is a `msg!` log or a `sol_log_data` log.
-    if (log.startsWith(PROGRAM_LOG) || log.startsWith(PROGRAM_DATA)) {
-      const logStr = log.startsWith(PROGRAM_LOG)
-        ? log.slice(PROGRAM_LOG_START_INDEX)
-        : log.slice(PROGRAM_DATA_START_INDEX);
+    // This is a `sol_log_data` log.
+    if (log.startsWith(PROGRAM_DATA)) {
+      const logStr = log.slice(PROGRAM_DATA_START_INDEX);
       const event = this.coder.events.decode(logStr);
 
       if (errorOnDecodeFailure && event === null) {


### PR DESCRIPTION
Anchor decodes events by checking if the transaction log line starts with "Program log:" (msg! system call) or "Program data" (sol_log_data system call).
This means that it attempts to decode all program logs.
After anchor 0.23.0 (2022-03-20) anchor switched to emitting events using the sol_log_data system_call (https://github.com/coral-xyz/anchor/pull/1608).
This created a clear distinction between anchor events logs and logs for other purposes.

The problem being that when you pass errorOnDecodeFailure=true to parseLogs it will fail on all non anchor event program logs.
I propose deprecating attempting to parse msg! logs so anchor only attempts to parse genuine anchor event candidates.
 