### PR TITLE
ts: support enum without fields

### DIFF
--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -195,7 +195,7 @@ declare type DecodeEnumFields<
  */
 declare type DecodeEnum<K extends IdlTypeDefTyEnum, Defined> = {
   // X = IdlEnumVariant
-  [X in K["variants"][number] as Uncapitalize<X["name"]>]+?: X["fields"] extends unknown[] ? DecodeEnumFields<
+  [X in K["variants"][number] as Uncapitalize<X["name"]>]+?: X["fields"] extends IdlEnumFields ? DecodeEnumFields<
     NonNullable<X["fields"]>,
     Defined
   > : { [P in Uncapitalize<X['name']>]: {} };

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -195,10 +195,10 @@ declare type DecodeEnumFields<
  */
 declare type DecodeEnum<K extends IdlTypeDefTyEnum, Defined> = {
   // X = IdlEnumVariant
-  [X in K["variants"][number] as Uncapitalize<X["name"]>]+?: DecodeEnumFields<
+  [X in K["variants"][number] as Uncapitalize<X["name"]>]+?: X["fields"] extends unknown[] ? DecodeEnumFields<
     NonNullable<X["fields"]>,
     Defined
-  >;
+  > : { [P in Uncapitalize<X['name']>]: {} };
 };
 
 type DecodeStruct<I extends IdlTypeDefTyStruct, Defined> = {

--- a/ts/packages/anchor/tests/types.spec.ts
+++ b/ts/packages/anchor/tests/types.spec.ts
@@ -1,0 +1,84 @@
+import { IdlTypes } from "../src/program/namespace/types";
+
+type IdlWithEnum = {
+  version: "0.1.0";
+  name: "blockchain";
+  instructions: [];
+  types: [
+    {
+      name: "Currency";
+      type: {
+        kind: "enum";
+        variants: [
+          {
+            name: "Sol";
+          },
+          {
+            name: "Usdc";
+          }
+        ];
+      };
+    }
+  ];
+};
+
+describe("types", () => {
+  describe("IdlTypes", () => {
+    it("covers enum with only name", () => {
+      type Currency = IdlTypes<IdlWithEnum>["Currency"];
+      typeCheck<
+        Currency,
+        {
+          sol?: { sol: {} };
+          usdc?: { usdc: {} };
+        }
+      >("ok");
+
+      expect(1).toEqual(1);
+    });
+  });
+});
+
+export type FunctionParameters = unknown[];
+
+type IsAny<T, Yes, No> = 0 extends 1 & T ? Yes : No;
+type FunctionType<R = any, P extends FunctionParameters = any[]> = (
+  ...args: P
+) => R;
+type IfElse<T, R, Yes> = IsAny<
+  T,
+  // (1) return Yes if R is any and T otherwise
+  IsAny<R, Yes, T>,
+  // (2) return T if Result is any and Yes otherwise
+  IsAny<R, T, Yes>
+>;
+type EqualReformat<T> = T extends FunctionType
+  ? [
+      "$$FunctionType$$",
+      EqualReformat<ReturnType<T>>,
+      EqualReformat<Parameters<T>>
+    ]
+  : T extends object
+  ? {
+      [K in keyof T]: EqualReformat<T[K]>;
+    }
+  : // never is an error, so if any we want to throw an error
+    IsAny<T, never, T>;
+type IfEqual<T1, T2, Yes, No> = [T2] extends [T1]
+  ? [T1] extends [T2]
+    ? Yes
+    : No
+  : No;
+
+type IfDeepEqual<T, R, Yes, No> = IfEqual<
+  EqualReformat<T>,
+  EqualReformat<R>,
+  Yes,
+  No
+>;
+
+function typeCheck<T, R, Yes = "ok">(
+  ok: IfDeepEqual<T, R, IfElse<T, R, Yes>, T>
+): unknown {
+  return ok;
+}


### PR DESCRIPTION
Hi

**Problem**
Right now if you are using simple rust enum 
```rust
#[derive(AnchorDeserialize, AnchorSerialize, Clone)]
pub enum Currency {
    Sol,
    Usdc,
}
```

you will get next idl
```typescript
// blabla
types: [
    {
      name: "Currency";
      type: {
        kind: "enum";
        variants: [
          {
            name: "Sol";
          },
          {
            name: "Usdc";
          }
        ];
      };
    }
  ];
// blabla
```

And if you try to extract type in your app with the `IdlTypes` utility
 
```typescript
type Currency = IdlTypes<YourIdl>['Currency'];
```

you will get smth like this
<img width="386" alt="image" src="https://user-images.githubusercontent.com/30667180/212483797-167e5683-0b2e-4912-86a0-aaae55379422.png">

**Solution**
Lets fix generics and add a test 🗡️ 

**Hint**
If you are using so extremely advanced generics, it's also a good idea to test them; I added a utility and basic test for my scenario, which allows validating the output type 

If you get the wrong type test throws an error smth like this
<img width="1225" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/30667180/212483502-631f5056-3876-412e-920d-d2453535bf02.png">

Peace