### PR TITLE
`to_account_metas()`macro with `Vec::with_capacity(#length)`

### DIFF
--- a/lang/src/accounts/account.rs
+++ b/lang/src/accounts/account.rs
@@ -4,7 +4,7 @@ use crate::bpf_writer::BpfWriter;
 use crate::error::{Error, ErrorCode};
 use crate::{
     AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Owner,
-    Result, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+    Result, ToAccountInfo, ToAccountInfos, ToAccountMeta, ToAccountMetas,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
@@ -356,16 +356,24 @@ impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> AccountsCl
     }
 }
 
-impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> ToAccountMetas
+impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> ToAccountMeta
     for Account<'info, T>
 {
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
         let is_signer = is_signer.unwrap_or(self.info.is_signer);
         let meta = match self.info.is_writable {
             false => AccountMeta::new_readonly(*self.info.key, is_signer),
             true => AccountMeta::new(*self.info.key, is_signer),
         };
-        vec![meta]
+        meta
+    }
+}
+
+impl<'info, T: AccountSerialize + AccountDeserialize + Owner + Clone> ToAccountMetas
+    for Account<'info, T>
+{
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
     }
 }
 

--- a/lang/src/accounts/account_info.rs
+++ b/lang/src/accounts/account_info.rs
@@ -3,7 +3,7 @@
 //! should be used instead.
 
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMeta, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
@@ -26,14 +26,20 @@ impl<'info> Accounts<'info> for AccountInfo<'info> {
     }
 }
 
-impl<'info> ToAccountMetas for AccountInfo<'info> {
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+impl<'info> ToAccountMeta for AccountInfo<'info> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
         let is_signer = is_signer.unwrap_or(self.is_signer);
         let meta = match self.is_writable {
             false => AccountMeta::new_readonly(*self.key, is_signer),
             true => AccountMeta::new(*self.key, is_signer),
         };
-        vec![meta]
+        meta
+    }
+}
+
+impl<'info> ToAccountMetas for AccountInfo<'info> {
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
     }
 }
 

--- a/lang/src/accounts/boxed.rs
+++ b/lang/src/accounts/boxed.rs
@@ -13,7 +13,9 @@
 //! }
 //! ```
 
-use crate::{Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas};
+use crate::{
+    Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMeta, ToAccountMetas,
+};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
@@ -41,6 +43,12 @@ impl<'info, T: AccountsExit<'info>> AccountsExit<'info> for Box<T> {
 impl<'info, T: ToAccountInfos<'info>> ToAccountInfos<'info> for Box<T> {
     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
         T::to_account_infos(self)
+    }
+}
+
+impl<T: ToAccountMeta> ToAccountMeta for Box<T> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
+        T::to_account_meta(self, is_signer)
     }
 }
 

--- a/lang/src/accounts/cpi_account.rs
+++ b/lang/src/accounts/cpi_account.rs
@@ -1,0 +1,136 @@
+use crate::*;
+use crate::{error::ErrorCode, prelude::Account};
+use solana_program::account_info::AccountInfo;
+use solana_program::instruction::AccountMeta;
+use solana_program::pubkey::Pubkey;
+use std::collections::BTreeMap;
+use std::ops::{Deref, DerefMut};
+
+/// Container for any account *not* owned by the current program.
+#[derive(Clone)]
+#[deprecated(since = "0.15.0", note = "Please use Account instead")]
+pub struct CpiAccount<'a, T: AccountDeserialize + Clone> {
+    info: AccountInfo<'a>,
+    account: Box<T>,
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountDeserialize + Clone> CpiAccount<'a, T> {
+    fn new(info: AccountInfo<'a>, account: Box<T>) -> CpiAccount<'a, T> {
+        Self { info, account }
+    }
+
+    /// Deserializes the given `info` into a `CpiAccount`.
+    pub fn try_from(info: &AccountInfo<'a>) -> Result<CpiAccount<'a, T>> {
+        let mut data: &[u8] = &info.try_borrow_data()?;
+        Ok(CpiAccount::new(
+            info.clone(),
+            Box::new(T::try_deserialize(&mut data)?),
+        ))
+    }
+
+    pub fn try_from_unchecked(info: &AccountInfo<'a>) -> Result<CpiAccount<'a, T>> {
+        Self::try_from(info)
+    }
+
+    /// Reloads the account from storage. This is useful, for example, when
+    /// observing side effects after CPI.
+    pub fn reload(&mut self) -> Result<()> {
+        let mut data: &[u8] = &self.info.try_borrow_data()?;
+        self.account = Box::new(T::try_deserialize(&mut data)?);
+        Ok(())
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T> Accounts<'info> for CpiAccount<'info, T>
+where
+    T: AccountDeserialize + Clone,
+{
+    #[inline(never)]
+    fn try_accounts(
+        _program_id: &Pubkey,
+        accounts: &mut &[AccountInfo<'info>],
+        _ix_data: &[u8],
+        _bumps: &mut BTreeMap<String, u8>,
+        _reallocs: &mut BTreeSet<Pubkey>,
+    ) -> Result<Self> {
+        if accounts.is_empty() {
+            return Err(ErrorCode::AccountNotEnoughKeys.into());
+        }
+        let account = &accounts[0];
+        *accounts = &accounts[1..];
+        // No owner check is done here.
+        let pa = CpiAccount::try_from(account)?;
+        Ok(pa)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountDeserialize + Clone> ToAccountMeta for CpiAccount<'info, T> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
+        let is_signer = is_signer.unwrap_or(self.info.is_signer);
+        let meta = match self.info.is_writable {
+            false => AccountMeta::new_readonly(*self.info.key, is_signer),
+            true => AccountMeta::new(*self.info.key, is_signer),
+        };
+        meta
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountDeserialize + Clone> ToAccountMetas for CpiAccount<'info, T> {
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountDeserialize + Clone> ToAccountInfos<'info> for CpiAccount<'info, T> {
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        vec![self.info.clone()]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountDeserialize + Clone> AsRef<AccountInfo<'info>> for CpiAccount<'info, T> {
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.info
+    }
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountDeserialize + Clone> Deref for CpiAccount<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.account
+    }
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountDeserialize + Clone> DerefMut for CpiAccount<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.account
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountDeserialize + Clone> AccountsExit<'info> for CpiAccount<'info, T> {}
+
+#[allow(deprecated)]
+impl<'info, T> From<Account<'info, T>> for CpiAccount<'info, T>
+where
+    T: AccountSerialize + AccountDeserialize + Owner + Clone,
+{
+    fn from(a: Account<'info, T>) -> Self {
+        Self::new(a.to_account_info(), Box::new(a.into_inner()))
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountDeserialize + Clone> Key for CpiAccount<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.info.key
+    }
+}

--- a/lang/src/accounts/cpi_state.rs
+++ b/lang/src/accounts/cpi_state.rs
@@ -1,0 +1,156 @@
+use crate::error::ErrorCode;
+#[allow(deprecated)]
+use crate::{accounts::state::ProgramState, context::CpiStateContext};
+use crate::{
+    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Key, Result, ToAccountInfos,
+    ToAccountMeta, ToAccountMetas,
+};
+use solana_program::account_info::AccountInfo;
+use solana_program::instruction::AccountMeta;
+use solana_program::pubkey::Pubkey;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::{Deref, DerefMut};
+
+/// Boxed container for the program state singleton, used when the state
+/// is for a program not currently executing.
+#[derive(Clone)]
+#[deprecated]
+pub struct CpiState<'info, T: AccountSerialize + AccountDeserialize + Clone> {
+    inner: Box<Inner<'info, T>>,
+}
+
+#[derive(Clone)]
+struct Inner<'info, T: AccountSerialize + AccountDeserialize + Clone> {
+    info: AccountInfo<'info>,
+    account: T,
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> CpiState<'info, T> {
+    pub fn new(i: AccountInfo<'info>, account: T) -> CpiState<'info, T> {
+        Self {
+            inner: Box::new(Inner { info: i, account }),
+        }
+    }
+
+    /// Deserializes the given `info` into a `CpiState`.
+    #[inline(never)]
+    pub fn try_from(info: &AccountInfo<'info>) -> Result<CpiState<'info, T>> {
+        let mut data: &[u8] = &info.try_borrow_data()?;
+        Ok(CpiState::new(info.clone(), T::try_deserialize(&mut data)?))
+    }
+
+    fn seed() -> &'static str {
+        ProgramState::<T>::seed()
+    }
+
+    pub fn address(program_id: &Pubkey) -> Pubkey {
+        let (base, _nonce) = Pubkey::find_program_address(&[], program_id);
+        let seed = Self::seed();
+        let owner = program_id;
+        Pubkey::create_with_seed(&base, seed, owner).unwrap()
+    }
+
+    /// Convenience api for creating a `CpiStateContext`.
+    pub fn context<'a, 'b, 'c, A: Accounts<'info>>(
+        &self,
+        program: AccountInfo<'info>,
+        accounts: A,
+    ) -> CpiStateContext<'a, 'b, 'c, 'info, A> {
+        CpiStateContext::new(program, self.inner.info.clone(), accounts)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T> Accounts<'info> for CpiState<'info, T>
+where
+    T: AccountSerialize + AccountDeserialize + Clone,
+{
+    #[inline(never)]
+    fn try_accounts(
+        _program_id: &Pubkey,
+        accounts: &mut &[AccountInfo<'info>],
+        _ix_data: &[u8],
+        _bumps: &mut BTreeMap<String, u8>,
+        _reallocs: &mut BTreeSet<Pubkey>,
+    ) -> Result<Self> {
+        if accounts.is_empty() {
+            return Err(ErrorCode::AccountNotEnoughKeys.into());
+        }
+        let account = &accounts[0];
+        *accounts = &accounts[1..];
+
+        // No owner or address check is done here. One must use the
+        // #[account(state = <account-name>)] constraint.
+
+        CpiState::try_from(account)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMeta for CpiState<'info, T> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
+        let is_signer = is_signer.unwrap_or(self.inner.info.is_signer);
+        let meta = match self.inner.info.is_writable {
+            false => AccountMeta::new_readonly(*self.inner.info.key, is_signer),
+            true => AccountMeta::new(*self.inner.info.key, is_signer),
+        };
+        meta
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMetas
+    for CpiState<'info, T>
+{
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfos<'info>
+    for CpiState<'info, T>
+{
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        vec![self.inner.info.clone()]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
+    for CpiState<'info, T>
+{
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.inner.info
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Deref for CpiState<'info, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &(self.inner).account
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> DerefMut for CpiState<'info, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut DerefMut::deref_mut(&mut self.inner).account
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info>
+    for CpiState<'info, T>
+{
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for CpiState<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.inner.info.key
+    }
+}

--- a/lang/src/accounts/option.rs
+++ b/lang/src/accounts/option.rs
@@ -15,7 +15,8 @@ use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 
 use crate::{
-    error::ErrorCode, Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMetas,
+    error::ErrorCode, Accounts, AccountsClose, AccountsExit, Result, ToAccountInfos, ToAccountMeta,
+    ToAccountMetas,
 };
 
 impl<'info, T: Accounts<'info>> Accounts<'info> for Option<T> {
@@ -59,6 +60,14 @@ impl<'info, T: ToAccountInfos<'info>> ToAccountInfos<'info> for Option<T> {
     fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
         self.as_ref()
             .map_or_else(Vec::new, |account| account.to_account_infos())
+    }
+}
+
+impl<T: ToAccountMeta> ToAccountMeta for Option<T> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
+        self.as_ref()
+            .expect("Cannot run `to_account_meta` on None")
+            .to_account_meta(is_signer)
     }
 }
 

--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -2,7 +2,8 @@
 
 use crate::error::{Error, ErrorCode};
 use crate::{
-    AccountDeserialize, Accounts, AccountsExit, Id, Key, Result, ToAccountInfos, ToAccountMetas,
+    AccountDeserialize, Accounts, AccountsExit, Id, Key, Result, ToAccountInfos, ToAccountMeta,
+    ToAccountMetas,
 };
 use solana_program::account_info::AccountInfo;
 use solana_program::bpf_loader_upgradeable::{self, UpgradeableLoaderState};
@@ -158,14 +159,20 @@ where
     }
 }
 
-impl<'info, T: Id + Clone> ToAccountMetas for Program<'info, T> {
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+impl<'info, T: Id + Clone> ToAccountMeta for Program<'info, T> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
         let is_signer = is_signer.unwrap_or(self.info.is_signer);
         let meta = match self.info.is_writable {
             false => AccountMeta::new_readonly(*self.info.key, is_signer),
             true => AccountMeta::new(*self.info.key, is_signer),
         };
-        vec![meta]
+        meta
+    }
+}
+
+impl<'info, T: Id + Clone> ToAccountMetas for Program<'info, T> {
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
     }
 }
 

--- a/lang/src/accounts/program_account.rs
+++ b/lang/src/accounts/program_account.rs
@@ -1,0 +1,201 @@
+#[allow(deprecated)]
+use crate::accounts::cpi_account::CpiAccount;
+use crate::bpf_writer::BpfWriter;
+use crate::error::{Error, ErrorCode};
+use crate::{
+    AccountDeserialize, AccountSerialize, Accounts, AccountsClose, AccountsExit, Key, Result,
+    ToAccountInfo, ToAccountInfos, ToAccountMeta, ToAccountMetas,
+};
+use solana_program::account_info::AccountInfo;
+use solana_program::instruction::AccountMeta;
+use solana_program::pubkey::Pubkey;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::{Deref, DerefMut};
+
+/// Boxed container for a deserialized `account`. Use this to reference any
+/// account owned by the currently executing program.
+#[derive(Clone)]
+#[deprecated(since = "0.15.0", note = "Please use Account instead")]
+pub struct ProgramAccount<'info, T: AccountSerialize + AccountDeserialize + Clone> {
+    inner: Box<Inner<'info, T>>,
+}
+
+#[derive(Clone)]
+struct Inner<'info, T: AccountSerialize + AccountDeserialize + Clone> {
+    info: AccountInfo<'info>,
+    account: T,
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramAccount<'a, T> {
+    fn new(info: AccountInfo<'a>, account: T) -> ProgramAccount<'a, T> {
+        Self {
+            inner: Box::new(Inner { info, account }),
+        }
+    }
+
+    /// Deserializes the given `info` into a `ProgramAccount`.
+    #[inline(never)]
+    pub fn try_from(program_id: &Pubkey, info: &AccountInfo<'a>) -> Result<ProgramAccount<'a, T>> {
+        if info.owner != program_id {
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys((*info.owner, *program_id)));
+        }
+        let mut data: &[u8] = &info.try_borrow_data()?;
+        Ok(ProgramAccount::new(
+            info.clone(),
+            T::try_deserialize(&mut data)?,
+        ))
+    }
+
+    /// Deserializes the given `info` into a `ProgramAccount` without checking
+    /// the account discriminator. Be careful when using this and avoid it if
+    /// possible.
+    #[inline(never)]
+    pub fn try_from_unchecked(
+        program_id: &Pubkey,
+        info: &AccountInfo<'a>,
+    ) -> Result<ProgramAccount<'a, T>> {
+        if info.owner != program_id {
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys((*info.owner, *program_id)));
+        }
+        let mut data: &[u8] = &info.try_borrow_data()?;
+        Ok(ProgramAccount::new(
+            info.clone(),
+            T::try_deserialize_unchecked(&mut data)?,
+        ))
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner.account
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T> Accounts<'info> for ProgramAccount<'info, T>
+where
+    T: AccountSerialize + AccountDeserialize + Clone,
+{
+    #[inline(never)]
+    fn try_accounts(
+        program_id: &Pubkey,
+        accounts: &mut &[AccountInfo<'info>],
+        _ix_data: &[u8],
+        _bumps: &mut BTreeMap<String, u8>,
+        _reallocs: &mut BTreeSet<Pubkey>,
+    ) -> Result<Self> {
+        if accounts.is_empty() {
+            return Err(ErrorCode::AccountNotEnoughKeys.into());
+        }
+        let account = &accounts[0];
+        *accounts = &accounts[1..];
+        ProgramAccount::try_from(program_id, account)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info>
+    for ProgramAccount<'info, T>
+{
+    fn exit(&self, _program_id: &Pubkey) -> Result<()> {
+        // Only persist if the account is not closed.
+        if !crate::common::is_closed(&self.inner.info) {
+            let info = self.to_account_info();
+            let mut data = info.try_borrow_mut_data()?;
+            let dst: &mut [u8] = &mut data;
+            let mut writer = BpfWriter::new(dst);
+            self.inner.account.try_serialize(&mut writer)?;
+        }
+        Ok(())
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsClose<'info>
+    for ProgramAccount<'info, T>
+{
+    fn close(&self, sol_destination: AccountInfo<'info>) -> Result<()> {
+        crate::common::close(self.to_account_info(), sol_destination)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMeta
+    for ProgramAccount<'info, T>
+{
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
+        let is_signer = is_signer.unwrap_or(self.inner.info.is_signer);
+        let meta = match self.inner.info.is_writable {
+            false => AccountMeta::new_readonly(*self.inner.info.key, is_signer),
+            true => AccountMeta::new(*self.inner.info.key, is_signer),
+        };
+        meta
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMetas
+    for ProgramAccount<'info, T>
+{
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfos<'info>
+    for ProgramAccount<'info, T>
+{
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        vec![self.inner.info.clone()]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
+    for ProgramAccount<'info, T>
+{
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.inner.info
+    }
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramAccount<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &(self.inner).account
+    }
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> DerefMut for ProgramAccount<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        #[cfg(feature = "anchor-debug")]
+        if !self.inner.info.is_writable {
+            solana_program::msg!("The given ProgramAccount is not mutable");
+            panic!();
+        }
+
+        &mut DerefMut::deref_mut(&mut self.inner).account
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T> From<CpiAccount<'info, T>> for ProgramAccount<'info, T>
+where
+    T: AccountSerialize + AccountDeserialize + Clone,
+{
+    fn from(a: CpiAccount<'info, T>) -> Self {
+        Self::new(a.to_account_info(), Deref::deref(&a).clone())
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for ProgramAccount<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.inner.info.key
+    }
+}

--- a/lang/src/accounts/signer.rs
+++ b/lang/src/accounts/signer.rs
@@ -1,6 +1,6 @@
 //! Type validating that the account signed the transaction
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMeta, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
@@ -74,14 +74,20 @@ impl<'info> Accounts<'info> for Signer<'info> {
 
 impl<'info> AccountsExit<'info> for Signer<'info> {}
 
-impl<'info> ToAccountMetas for Signer<'info> {
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+impl<'info> ToAccountMeta for Signer<'info> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
         let is_signer = is_signer.unwrap_or(self.info.is_signer);
         let meta = match self.info.is_writable {
             false => AccountMeta::new_readonly(*self.info.key, is_signer),
             true => AccountMeta::new(*self.info.key, is_signer),
         };
-        vec![meta]
+        meta
+    }
+}
+
+impl<'info> ToAccountMetas for Signer<'info> {
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
     }
 }
 

--- a/lang/src/accounts/state.rs
+++ b/lang/src/accounts/state.rs
@@ -1,0 +1,180 @@
+#[allow(deprecated)]
+use crate::accounts::cpi_account::CpiAccount;
+use crate::bpf_writer::BpfWriter;
+use crate::error::{Error, ErrorCode};
+use crate::{
+    AccountDeserialize, AccountSerialize, Accounts, AccountsExit, Key, Result, ToAccountInfo,
+    ToAccountInfos, ToAccountMeta, ToAccountMetas,
+};
+use solana_program::account_info::AccountInfo;
+use solana_program::instruction::AccountMeta;
+use solana_program::pubkey::Pubkey;
+use std::collections::{BTreeMap, BTreeSet};
+use std::ops::{Deref, DerefMut};
+
+pub const PROGRAM_STATE_SEED: &str = "unversioned";
+
+/// Boxed container for the program state singleton.
+#[derive(Clone)]
+#[deprecated]
+pub struct ProgramState<'info, T: AccountSerialize + AccountDeserialize + Clone> {
+    inner: Box<Inner<'info, T>>,
+}
+
+#[derive(Clone)]
+struct Inner<'info, T: AccountSerialize + AccountDeserialize + Clone> {
+    info: AccountInfo<'info>,
+    account: T,
+}
+
+#[allow(deprecated)]
+
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> ProgramState<'a, T> {
+    fn new(info: AccountInfo<'a>, account: T) -> ProgramState<'a, T> {
+        Self {
+            inner: Box::new(Inner { info, account }),
+        }
+    }
+
+    /// Deserializes the given `info` into a `ProgramState`.
+    #[inline(never)]
+    pub fn try_from(program_id: &Pubkey, info: &AccountInfo<'a>) -> Result<ProgramState<'a, T>> {
+        if info.owner != program_id {
+            return Err(Error::from(ErrorCode::AccountOwnedByWrongProgram)
+                .with_pubkeys((*info.owner, *program_id)));
+        }
+        if info.key != &Self::address(program_id) {
+            solana_program::msg!("Invalid state address");
+            return Err(ErrorCode::StateInvalidAddress.into());
+        }
+        let mut data: &[u8] = &info.try_borrow_data()?;
+        Ok(ProgramState::new(
+            info.clone(),
+            T::try_deserialize(&mut data)?,
+        ))
+    }
+
+    pub fn seed() -> &'static str {
+        PROGRAM_STATE_SEED
+    }
+
+    pub fn address(program_id: &Pubkey) -> Pubkey {
+        address(program_id)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T> Accounts<'info> for ProgramState<'info, T>
+where
+    T: AccountSerialize + AccountDeserialize + Clone,
+{
+    #[inline(never)]
+    fn try_accounts(
+        program_id: &Pubkey,
+        accounts: &mut &[AccountInfo<'info>],
+        _ix_data: &[u8],
+        _bumps: &mut BTreeMap<String, u8>,
+        _reallocs: &mut BTreeSet<Pubkey>,
+    ) -> Result<Self> {
+        if accounts.is_empty() {
+            return Err(ErrorCode::AccountNotEnoughKeys.into());
+        }
+        let account = &accounts[0];
+        *accounts = &accounts[1..];
+        ProgramState::try_from(program_id, account)
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMeta
+    for ProgramState<'info, T>
+{
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
+        let is_signer = is_signer.unwrap_or(self.inner.info.is_signer);
+        let meta = match self.inner.info.is_writable {
+            false => AccountMeta::new_readonly(*self.inner.info.key, is_signer),
+            true => AccountMeta::new(*self.inner.info.key, is_signer),
+        };
+        meta
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountMetas
+    for ProgramState<'info, T>
+{
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> ToAccountInfos<'info>
+    for ProgramState<'info, T>
+{
+    fn to_account_infos(&self) -> Vec<AccountInfo<'info>> {
+        vec![self.inner.info.clone()]
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AsRef<AccountInfo<'info>>
+    for ProgramState<'info, T>
+{
+    fn as_ref(&self) -> &AccountInfo<'info> {
+        &self.inner.info
+    }
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> Deref for ProgramState<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &(self.inner).account
+    }
+}
+
+#[allow(deprecated)]
+impl<'a, T: AccountSerialize + AccountDeserialize + Clone> DerefMut for ProgramState<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut DerefMut::deref_mut(&mut self.inner).account
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T> From<CpiAccount<'info, T>> for ProgramState<'info, T>
+where
+    T: AccountSerialize + AccountDeserialize + Clone,
+{
+    fn from(a: CpiAccount<'info, T>) -> Self {
+        Self::new(a.to_account_info(), Deref::deref(&a).clone())
+    }
+}
+
+#[allow(deprecated)]
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> AccountsExit<'info>
+    for ProgramState<'info, T>
+{
+    fn exit(&self, _program_id: &Pubkey) -> Result<()> {
+        let info = self.to_account_info();
+        let mut data = info.try_borrow_mut_data()?;
+        let dst: &mut [u8] = &mut data;
+        let mut writer = BpfWriter::new(dst);
+        self.inner.account.try_serialize(&mut writer)?;
+        Ok(())
+    }
+}
+
+pub fn address(program_id: &Pubkey) -> Pubkey {
+    let (base, _nonce) = Pubkey::find_program_address(&[], program_id);
+    let seed = PROGRAM_STATE_SEED;
+    let owner = program_id;
+    Pubkey::create_with_seed(&base, seed, owner).unwrap()
+}
+
+impl<'info, T: AccountSerialize + AccountDeserialize + Clone> Key for ProgramState<'info, T> {
+    fn key(&self) -> Pubkey {
+        *self.inner.info.key
+    }
+}

--- a/lang/src/accounts/system_account.rs
+++ b/lang/src/accounts/system_account.rs
@@ -53,14 +53,20 @@ impl<'info> Accounts<'info> for SystemAccount<'info> {
 
 impl<'info> AccountsExit<'info> for SystemAccount<'info> {}
 
-impl<'info> ToAccountMetas for SystemAccount<'info> {
-    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+impl<'info> ToAccountMeta for SystemAccount<'info> {
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta {
         let is_signer = is_signer.unwrap_or(self.info.is_signer);
         let meta = match self.info.is_writable {
             false => AccountMeta::new_readonly(*self.info.key, is_signer),
             true => AccountMeta::new(*self.info.key, is_signer),
         };
-        vec![meta]
+        meta
+    }
+}
+
+impl<'info> ToAccountMetas for SystemAccount<'info> {
+    fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta> {
+        vec![self.to_account_meta(is_signer)]
     }
 }
 

--- a/lang/src/accounts/sysvar.rs
+++ b/lang/src/accounts/sysvar.rs
@@ -1,7 +1,7 @@
 //! Type validating that the account is a sysvar and deserializing it
 
 use crate::error::ErrorCode;
-use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMetas};
+use crate::{Accounts, AccountsExit, Key, Result, ToAccountInfos, ToAccountMeta, ToAccountMetas};
 use solana_program::account_info::AccountInfo;
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
@@ -79,6 +79,12 @@ impl<'info, T: solana_program::sysvar::Sysvar> Accounts<'info> for Sysvar<'info,
         let account = &accounts[0];
         *accounts = &accounts[1..];
         Sysvar::from_account_info(account)
+    }
+}
+
+impl<'info, T: solana_program::sysvar::Sysvar> ToAccountMeta for Sysvar<'info, T> {
+    fn to_account_meta(&self, _is_signer: Option<bool>) -> AccountMeta {
+        AccountMeta::new_readonly(*self.info.key, false)
     }
 }
 

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -112,6 +112,18 @@ pub trait ToAccountMetas {
     fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<AccountMeta>;
 }
 
+/// Transformation to an
+/// [`AccountMeta`](../solana_program/instruction/struct.AccountMeta.html)
+/// struct.
+pub trait ToAccountMeta {
+    /// `is_signer` is given as an optional override for the signer meta field.
+    /// This covers the edge case when a program-derived-address needs to relay
+    /// a transaction from a client to another program but sign the transaction
+    /// before the relay. The client cannot mark the field as a signer, and so
+    /// we have to override the is_signer meta field given by the client.
+    fn to_account_meta(&self, is_signer: Option<bool>) -> AccountMeta;
+}
+
 /// Transformation to
 /// [`AccountInfo`](../solana_program/account_info/struct.AccountInfo.html)
 /// structs.
@@ -252,8 +264,8 @@ pub mod prelude {
         require, require_eq, require_gt, require_gte, require_keys_eq, require_keys_neq,
         require_neq, solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
         system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
-        AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Id, InitSpace, Key, Owner,
-        ProgramData, Result, Space, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+        AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Id, Key, Owner,
+        ProgramData, Result, ToAccountInfo, ToAccountInfos, ToAccountMeta, ToAccountMetas,
     };
     pub use anchor_attribute_error::*;
     pub use borsh;

--- a/lang/syn/src/codegen/accounts/to_account_metas.rs
+++ b/lang/syn/src/codegen/accounts/to_account_metas.rs
@@ -22,14 +22,14 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
             if is_optional {
                 quote! {
                     if let Some(#name) = &self.#name {
-                        account_metas.push(#name.to_account_metas(#is_signer));
+                        account_metas.push(#name.to_account_meta(#is_signer));
                     } else {
                         account_metas.push(AccountMeta::new_readonly(crate::ID, false));
                     }
                 }
             } else {
                 quote! {
-                    account_metas.push(self.#name.to_account_metas(#is_signer));
+                    account_metas.push(self.#name.to_account_meta(#is_signer));
                 }
             }
         })
@@ -43,7 +43,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         #[automatically_derived]
         impl #impl_gen anchor_lang::ToAccountMetas for #name #ty_gen #where_clause{
             fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<anchor_lang::solana_program::instruction::AccountMeta> {
-                // let mut account_metas = vec![];
+                use anchor_lang::ToAccountMeta;
+
                 let mut account_metas = Vec::with_capacity(#length);
 
                 #(#to_acc_metas)*

--- a/lang/syn/src/codegen/accounts/to_account_metas.rs
+++ b/lang/syn/src/codegen/accounts/to_account_metas.rs
@@ -22,18 +22,20 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
             if is_optional {
                 quote! {
                     if let Some(#name) = &self.#name {
-                        account_metas.extend(#name.to_account_metas(#is_signer));
+                        account_metas.push(#name.to_account_metas(#is_signer));
                     } else {
                         account_metas.push(AccountMeta::new_readonly(crate::ID, false));
                     }
                 }
             } else {
                 quote! {
-                    account_metas.extend(self.#name.to_account_metas(#is_signer));
+                    account_metas.push(self.#name.to_account_metas(#is_signer));
                 }
             }
         })
         .collect();
+
+    let length = to_acc_metas.len();
 
     let (impl_gen, ty_gen, where_clause) = accs.generics.split_for_impl();
 
@@ -41,7 +43,8 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         #[automatically_derived]
         impl #impl_gen anchor_lang::ToAccountMetas for #name #ty_gen #where_clause{
             fn to_account_metas(&self, is_signer: Option<bool>) -> Vec<anchor_lang::solana_program::instruction::AccountMeta> {
-                let mut account_metas = vec![];
+                // let mut account_metas = vec![];
+                let mut account_metas = Vec::with_capacity(#length);
 
                 #(#to_acc_metas)*
 


### PR DESCRIPTION
Problem
- Up until this point, the `to_account_metas()` macro would use `.extend()` to append account metas to an already allocated vec which would make for unnecessary memory allocations which would also waste compute units. 

Solution
- Introduce `ToAccountMeta` trait that allowed us to:
   - introduce `to_account_meta()` method that returns a single account meta for the same number of `ToAccountMetas` implentations
   - update `to_account_metas()` method implementations that return a vec of `to_account_meta()`
- update `to_account_metas()` macro to: 
   - take into account the number of accounts in `Context<T>` and use that as an arg to pass into `Vec::with_capacity(#length)`
   - use `.push()` instead of `.extend()` when adding account metas to the vec which rids of the unnecessary memory allocations

Previously: 
<img width="732" alt="Screenshot 2023-02-15 at 9 39 51 PM" src="https://user-images.githubusercontent.com/20745708/219270346-2cc5c4e2-5bca-43c9-970f-be44faa77917.png">
Now: 
<img width="702" alt="Screenshot 2023-02-15 at 9 40 06 PM" src="https://user-images.githubusercontent.com/20745708/219270358-e7aab06c-5c34-4655-ab6c-de5764c19c0e.png">

cc: shoutout @cavemanloverboy & @nickgarfield for doing all of the heavy lifting. Just trying to get this PR submission across the finish line.