### PR TITLE
`to_account_infos()` macro with `Vec::with_capacity(#length)`

### DIFF
--- a/lang/syn/src/codegen/accounts/to_account_infos.rs
+++ b/lang/syn/src/codegen/accounts/to_account_infos.rs
@@ -17,14 +17,19 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
         .iter()
         .map(|f: &AccountField| {
             let name = &f.ident();
-            quote! { account_infos.extend(self.#name.to_account_infos()); }
+            quote! { account_infos.push(self.#name.to_account_info()); }
         })
         .collect();
+
+    let length = to_acc_infos.len();
+
     quote! {
         #[automatically_derived]
         impl<#combined_generics> anchor_lang::ToAccountInfos<#trait_generics> for #name <#struct_generics> #where_clause{
             fn to_account_infos(&self) -> Vec<anchor_lang::solana_program::account_info::AccountInfo<'info>> {
-                let mut account_infos = vec![];
+                use anchor_lang::ToAccountInfo;
+
+                let mut account_infos = Vec::with_capacity(#length);
 
                 #(#to_acc_infos)*
 


### PR DESCRIPTION
Problem
- similar to [PR 2399](https://github.com/coral-xyz/anchor/pull/2399), the `to_account_infos()` macro would use `.extend()` to append account infos to an already allocated vec which would make for unnecessary memory allocations which would also waste compute units.

Solution
- update `to_account_infos()` macro to: 
   - take into account the number of accounts infos in `AccountField` and use that as an arg to pass into `Vec::with_capacity(#length)`
   - use `.push()` instead of `.extend()` when adding account infos to the vec which rids of the unnecessary memory allocations

Previously:
<img width="723" alt="Screenshot 2023-02-16 at 12 36 04 PM" src="https://user-images.githubusercontent.com/20745708/219468944-a2f4a7a4-b298-41ac-a090-5571394d2ec6.png">

Now:
<img width="742" alt="Screenshot 2023-02-16 at 12 31 14 PM" src="https://user-images.githubusercontent.com/20745708/219468745-635489d2-8c93-46e4-a465-d129a33fd533.png">


cc: @cavemanloverboy & @nickgarfield
