### PR TITLE
Fix Token 2022 ATA constraint

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -898,7 +898,7 @@ fn generate_constraint_associated_token(
         {
             #optional_checks
             let mint_program_id = {
-              let mint_account = #spl_token_mint_address.to_account_info();
+              let mint_account: &AccountInfo = #spl_token_mint_address.as_ref();
               mint_account.owner
             };
             let my_owner = #name.owner;

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -616,7 +616,7 @@ fn generate_constraint_init_group(
                     let pa: #ty_decl = #from_account_info_unchecked;
                     if #if_needed {
                         let mint_program_id = {
-                            let mint_account = #mint.to_account_info();
+                            let mint_account: &AccountInfo = #mint.as_ref();
                             mint_account.owner
                         };
 

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -879,7 +879,7 @@ fn generate_constraint_associated_token(
     let name = &f.ident;
     let name_str = name.to_string();
     let wallet_address = &c.wallet;
-    let spl_token_mint_address = &c.mint;
+    let spl_token_mint_address: &Expr = &c.mint;
     let mut optional_check_scope = OptionalCheckScope::new_with_field(accs, name);
     let wallet_address_optional_check = optional_check_scope.generate_check(wallet_address);
     let spl_token_mint_address_optional_check =
@@ -895,10 +895,12 @@ fn generate_constraint_associated_token(
 
             let my_owner = #name.owner;
             let wallet_address = #wallet_address.key();
+            let mint_info = #spl_token_mint_address.to_account_info();
             if my_owner != wallet_address {
                 return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenOwner).with_account_name(#name_str).with_pubkeys((my_owner, wallet_address)));
             }
-            let __associated_token_address = ::anchor_spl::associated_token::get_associated_token_address(&wallet_address, &#spl_token_mint_address.key());
+
+            let __associated_token_address = ::anchor_spl::associated_token::get_associated_token_address_with_program_id(&wallet_address, &#spl_token_mint_address.key(), *mint_info.owner);
             let my_key = #name.key();
             if my_key != __associated_token_address {
                 return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintAssociated).with_account_name(#name_str).with_pubkeys((my_key, __associated_token_address)));

--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -614,6 +614,7 @@ fn generate_constraint_init_group(
                         ::anchor_spl::associated_token::create(cpi_ctx)?;
                     }
                     let pa: #ty_decl = #from_account_info_unchecked;
+                    let mint_info = #mint.to_account_info();
                     if #if_needed {
                         if pa.mint != #mint.key() {
                             return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenMint).with_account_name(#name_str).with_pubkeys((pa.mint, #mint.key())));
@@ -622,7 +623,7 @@ fn generate_constraint_init_group(
                             return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintTokenOwner).with_account_name(#name_str).with_pubkeys((pa.owner, #owner.key())));
                         }
 
-                        if pa.key() != ::anchor_spl::associated_token::get_associated_token_address(&#owner.key(), &#mint.key()) {
+                        if pa.key() != ::anchor_spl::associated_token::get_associated_token_address_with_program_id(&#owner.key(), &#mint.key(), *mint_info.owner) {
                             return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::AccountNotAssociatedTokenAccount).with_account_name(#name_str));
                         }
                     }

--- a/tests/spl/token-proxy/programs/token-proxy/Cargo.toml
+++ b/tests/spl/token-proxy/programs/token-proxy/Cargo.toml
@@ -14,6 +14,6 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 
 [dependencies]
-anchor-lang = { path = "../../../../../lang" }
+anchor-lang = { path = "../../../../../lang", features=["init-if-needed"] }
 anchor-spl = { path = "../../../../../spl" }
 spl-token-2022 = { version = "0.5.0", features = ["no-entrypoint"] }

--- a/tests/spl/token-proxy/programs/token-proxy/src/lib.rs
+++ b/tests/spl/token-proxy/programs/token-proxy/src/lib.rs
@@ -170,7 +170,7 @@ pub struct ProxyCreateAssociatedTokenAccount<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
     #[account(
-        init,
+        init_if_needed,
         associated_token::mint = mint,
         payer = authority,
         associated_token::authority = authority,


### PR DESCRIPTION
Fixes #2434 for Token 2022 ATA constraints by using get_associated_token_address_with_program_id.