### PR TITLE
Fix order of init constraints when using `Mint` and `TokenAccount`

### DIFF
--- a/tests/misc/programs/misc-optional/src/context.rs
+++ b/tests/misc/programs/misc-optional/src/context.rs
@@ -710,3 +710,28 @@ pub struct TestAssociatedTokenWithTokenProgramConstraint<'info> {
     /// CHECK: ignore
     pub associated_token_token_program: Option<AccountInfo<'info>>,
 }
+
+#[derive(Accounts)]
+pub struct TestInitTokenAccountWithMintWrongOrder<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(
+        init,
+        token::authority = payer,
+        token::mint = mint,
+        payer = payer
+    )]
+    pub token: Option<Account<'info, TokenAccount>>,
+
+    #[account(
+        init,
+        mint::authority = payer,
+        mint::decimals = 0,
+        payer = payer
+    )]
+    pub mint: Account<'info, Mint>,
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+}

--- a/tests/misc/programs/misc-optional/src/lib.rs
+++ b/tests/misc/programs/misc-optional/src/lib.rs
@@ -404,4 +404,10 @@ pub mod misc_optional {
     pub fn test_associated_token_with_token_program_constraint(_ctx: Context<TestAssociatedTokenWithTokenProgramConstraint>) -> Result<()> {
         Ok(())
     }
+
+    pub fn test_init_token_account_with_mint_wrong_order(
+        _ctx: Context<TestInitTokenAccountWithMintWrongOrder>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -768,3 +768,28 @@ pub struct TestUsedIdentifiers<'info> {
     /// CHECK: ignore
     pub test4: AccountInfo<'info>,
 }
+
+#[derive(Accounts)]
+pub struct TestInitTokenAccountWithMintWrongOrder<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(
+        init,
+        token::authority = payer,
+        token::mint = mint,
+        payer = payer
+    )]
+    pub token: Account<'info, TokenAccount>,
+
+    #[account(
+        init,
+        mint::authority = payer,
+        mint::decimals = 0,
+        payer = payer
+    )]
+    pub mint: Account<'info, Mint>,
+
+    pub system_program: Program<'info, System>,
+    pub token_program: Program<'info, Token>,
+}

--- a/tests/misc/programs/misc/src/lib.rs
+++ b/tests/misc/programs/misc/src/lib.rs
@@ -403,4 +403,10 @@ pub mod misc {
     ) -> Result<()> {
         Ok(())
     }
+
+    pub fn test_init_token_account_with_mint_wrong_order(
+        _ctx: Context<TestInitTokenAccountWithMintWrongOrder>,
+    ) -> Result<()> {
+        Ok(())
+    }
 }

--- a/tests/misc/tests/misc/misc.ts
+++ b/tests/misc/tests/misc/misc.ts
@@ -3317,6 +3317,22 @@ const miscTest = (
         }
       });
     });
+
+    it("Init constraint ordering", async () => {
+      const mint = anchor.web3.Keypair.generate();
+      const token = anchor.web3.Keypair.generate();
+
+      await program.rpc.testInitTokenAccountWithMintWrongOrder({
+        accounts: {
+          payer: provider.wallet.publicKey,
+          token: token.publicKey,
+          mint: mint.publicKey,
+          systemProgram: anchor.web3.SystemProgram.programId,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        },
+        signers: [mint, token],
+      });
+    });
   };
 };
 


### PR DESCRIPTION
This is a proposal fixing the issue #2463.
I added a sort to ensure that init of `Mint` accounts are always first.

What do you think?