### PR TITLE
lang: Generate code at non-root levels, containing them in their own modules

### DIFF
--- a/lang/attribute/account/src/lib.rs
+++ b/lang/attribute/account/src/lib.rs
@@ -122,7 +122,7 @@ pub fn account(
                 #[automatically_derived]
                 impl #impl_gen anchor_lang::Owner for #account_name #type_gen #where_clause {
                     fn owner() -> Pubkey {
-                        crate::ID
+                        ID // crate::ID
                     }
                 }
             }

--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -103,7 +103,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         if let Some(#name) = &self.#name {
                             account_metas.push(#meta(*#name, #is_signer));
                         } else {
-                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(crate::ID, false));
+                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(super::ID, false));
                         }
                     }
                 } else {

--- a/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__cpi_client_accounts.rs
@@ -104,7 +104,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                         if let Some(#name) = &self.#name {
                             account_metas.push(#meta(anchor_lang::Key::key(#name), #is_signer));
                         } else {
-                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(crate::ID, false));
+                            account_metas.push(anchor_lang::solana_program::instruction::AccountMeta::new_readonly(super::ID, false));
                         }
                     }
                 } else {

--- a/lang/syn/src/codegen/accounts/to_account_metas.rs
+++ b/lang/syn/src/codegen/accounts/to_account_metas.rs
@@ -24,7 +24,7 @@ pub fn generate(accs: &AccountsStruct) -> proc_macro2::TokenStream {
                     if let Some(#name) = &self.#name {
                         account_metas.extend(#name.to_account_metas(#is_signer));
                     } else {
-                        account_metas.push(AccountMeta::new_readonly(crate::ID, false));
+                        account_metas.push(AccountMeta::new_readonly(super::ID, false));
                     }
                 }
             } else {

--- a/lang/syn/src/codegen/program/accounts.rs
+++ b/lang/syn/src/codegen/program/accounts.rs
@@ -22,7 +22,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .map(|macro_name: &String| {
             let macro_name: proc_macro2::TokenStream = macro_name.parse().unwrap();
             quote! {
-                pub use crate::#macro_name::*;
+                pub use super::#macro_name::*;
             }
         })
         .collect();

--- a/lang/syn/src/codegen/program/cpi.rs
+++ b/lang/syn/src/codegen/program/cpi.rs
@@ -9,7 +9,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         .ixs
         .iter()
         .map(|ix| {
-            let accounts_ident: proc_macro2::TokenStream = format!("crate::cpi::accounts::{}", &ix.anchor_ident.to_string()).parse().unwrap();
+            let accounts_ident: proc_macro2::TokenStream = format!("super::cpi::accounts::{}", &ix.anchor_ident.to_string()).parse().unwrap();
             let cpi_method = {
                 let ix_variant = generate_ix_variant(ix.raw_method.sig.ident.to_string(), &ix.args);
                 let method_name = &ix.ident;
@@ -22,8 +22,8 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 let (method_ret, maybe_return) = match ret_type.to_string().as_str() {
                     "()" => (quote! {anchor_lang::Result<()> }, quote! { Ok(()) }),
                     _ => (
-                        quote! { anchor_lang::Result<crate::cpi::Return::<#ret_type>> },
-                        quote! { Ok(crate::cpi::Return::<#ret_type> { phantom: crate::cpi::PhantomData }) }
+                        quote! { anchor_lang::Result<super::cpi::Return::<#ret_type>> },
+                        quote! { Ok(super::cpi::Return::<#ret_type> { phantom: super::cpi::PhantomData }) }
                     )
                 };
 
@@ -40,7 +40,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                             data.append(&mut ix_data);
                             let accounts = ctx.to_account_metas(None);
                             anchor_lang::solana_program::instruction::Instruction {
-                                program_id: crate::ID,
+                                program_id: super::ID,
                                 accounts,
                                 data,
                             }
@@ -110,7 +110,7 @@ pub fn generate_accounts(program: &Program) -> proc_macro2::TokenStream {
         .map(|macro_name: &String| {
             let macro_name: proc_macro2::TokenStream = macro_name.parse().unwrap();
             quote! {
-                pub use crate::#macro_name::*;
+                pub use super::#macro_name::*;
             }
         })
         .collect();

--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -29,7 +29,7 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
         // works. Namespaces are the root of most of the problem.
         impl anchor_lang::Owner for IdlAccount {
             fn owner() -> Pubkey {
-                crate::ID
+                super::ID
             }
         }
 


### PR DESCRIPTION
It's a non-breaking change. Everything, that works now, should continue to work the way they're supposed to.

_for best experience, please review commit by commit._

### What this PR is about?

 Currently `anchor` assumes that the generated code is at the root (`lib.rs`) level. So we have the following in the generated code:

- `crate::ID`
- `crate::cpi`
- `crate::__client_accounts_*`
- `crate::__cpi_client_accounts_*`

So this PR primarily changes the above to:

- `super::ID`
- `super::cpi`
- `super::__client_accounts_*`
- `super::__cpi_client_accounts_*`

so that the generated code are contained within their own modules. It has two implications:

- The users now can implement `#[program]` in a user-defined module and they do **not** have to bring them into `lib.rs` scope (using `use my_module::*`)
- But if users define them at `lib.rs` level (or bring them to this scope), like existing projects, the above two codes are _practically_ same, as `super::` would mean `crate::` in that case. Hence non-breaking change.

### So what is the advantage? 

Since this change allows users to define programs at non-root level, it enables them to define multiple programs within a single crate, share code (especially serializable/deserializable types) as much as possible, avoiding circular dependencies if any.  For details, see this issue: https://github.com/coral-xyz/anchor/issues/2493 (which this PR attempts to implement).

### Changes

There are basically (at most) 3 different sets of changes this PR should have:

- Change `crate::` to `super::`. It's the easiest and the smallest. See the first commit.
- Change IDL generation, as now we can have multiple programs, hence multiple IDL files (json and ts) can be generated. In the second commit, I've shown _one way_ of generating IDL but I'm not sure if that's the most sensible way, as now we can have more than one choices. So I'm looking forward to some advice as to how we should do it:
   - Generate separate IDL file for each program, in all builds.
   - Generate a single IDL file for all programs. 
   - Generate a single IDL file for a single program only whose `entrypoint!` is enabled. For this, we might have to add some flag to the CLI. 
   - We can also add a new section in `Anchor.toml`, say `[idl]`  where users can define their preferences. 
 - And the third sets of changes/addition is.. testcases, which I have not added yet. Will do that once we finalize the IDL generation part.
