### PR TITLE
Add `returnData` to ts tx `simulate`

### DIFF
--- a/examples/tutorial/basic-4/programs/basic-4/src/lib.rs
+++ b/examples/tutorial/basic-4/programs/basic-4/src/lib.rs
@@ -30,6 +30,10 @@ pub mod basic_4 {
         ctx.accounts.counter.count += 1;
         Ok(())
     }
+
+    pub fn get_count(ctx: Context<GetCount>) -> Result<u64> {
+        Ok(ctx.accounts.counter.count)
+    }
 }
 
 #[derive(Accounts)]
@@ -56,6 +60,11 @@ pub struct Increment<'info> {
     )]
     counter: Account<'info, Counter>,
     authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct GetCount<'info> {
+    counter: Account<'info, Counter>,
 }
 
 #[account]

--- a/examples/tutorial/basic-4/tests/basic-4.js
+++ b/examples/tutorial/basic-4/tests/basic-4.js
@@ -45,7 +45,14 @@ describe("basic-4", () => {
       })
       .rpc();
 
-    const counterAccount = await program.account.counter.fetch(counterPubkey);
-    assert.ok(counterAccount.count.eq(new anchor.BN(1)));
+    const response = await program.methods
+      .getCount()
+      .accounts({
+        counter: counterPubkey,
+      })
+      .simulate();
+    const count = response.returnData;
+
+    assert.ok(count.eq(new anchor.BN(1)));
   });
 });

--- a/ts/packages/anchor/src/program/namespace/simulate.ts
+++ b/ts/packages/anchor/src/program/namespace/simulate.ts
@@ -1,4 +1,4 @@
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey, TransactionReturnData } from "@solana/web3.js";
 import Provider from "../../provider.js";
 import { SuccessfulTxSimulationResponse } from "src/utils/rpc.js";
 import { splitArgsAndCtx } from "../context.js";
@@ -57,7 +57,7 @@ export default class SimulateFactory {
           events.push(event);
         }
       }
-      return { events, raw: logs };
+      return { events, raw: logs, rawReturnData: resp.returnData };
     };
 
     return simulate;
@@ -129,4 +129,5 @@ export type SimulateFn<
 export type SimulateResponse<E extends IdlEvent, Defined> = {
   events: readonly Event<E, Defined>[];
   raw: readonly string[];
+  rawReturnData?: TransactionReturnData | null;
 };


### PR DESCRIPTION
Today, the main method of accessing program state is fetching an account and deserializing its bytes. For example, given a program that stores a count in the following struct

```
#[account]
pub struct Counter {
    pub authority: Pubkey,
    pub count: u64,
    pub bump: u8,
}
```

one would determine `count` by fetching counter and deserializing bytes 32..40 of counter into an integer. This works fine for simple accounts, but not so well for more complex ones. For instance, many CLOBs store their orders in trees or linked lists ([example](https://github.com/openbook-dex/openbook-v2/blob/master/programs/openbook-v2/src/state/orderbook/ordertree.rs)). A client wishing to see the order book might need to so something like this:

```
sorted_orders
order_book = program.account.order_book.fetch(order_book_pk)
i = order_book.head
while i != NULL_MAGIC_NUMBER:
  sorted_orders.push(order_book.orders[i])
  i = order_book.orders[i].next_order
```

A developer could write an SDK to abstract this away from the user. However, given that Rust, C, Go, Python, and Javascript are all popular in the crypto ecosystem, this is likely to be a cumbersome task.

In my view, the solution to this is getters that are inside the program. Someone wanting to see a value would [simulate a transaction](https://docs.solana.com/api/http#simulatetransaction) where that getter is called. 

This PR would add a `returnData` field to `SimulateResponse` to allow for this.