### PR TITLE
Simplify the `anchor-spl` interface

### DIFF
--- a/tests/cashiers-check/programs/cashiers-check/src/lib.rs
+++ b/tests/cashiers-check/programs/cashiers-check/src/lib.rs
@@ -21,14 +21,14 @@ pub mod cashiers_check {
         nonce: u8,
     ) -> Result<()> {
         // Transfer funds to the check.
-        let cpi_accounts = Transfer {
-            from: ctx.accounts.from.to_account_info().clone(),
-            to: ctx.accounts.vault.to_account_info().clone(),
-            authority: ctx.accounts.owner.clone(),
-        };
-        let cpi_program = ctx.accounts.token_program.clone();
-        let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
-        token::transfer(cpi_ctx, amount)?;
+        // let cpi_accounts = Transfer {
+        //     from: ctx.accounts.from.to_account_info().clone(),
+        //     to: ctx.accounts.vault.to_account_info().clone(),
+        //     authority: ctx.accounts.owner.clone(),
+        // };
+        // let cpi_program = ctx.accounts.token_program.clone();
+        // let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+        token::transfer(&ctx.accounts.from, &ctx.accounts.vault, &ctx.accounts.owner, None, amount)?;
 
         // Print the check.
         let check = &mut ctx.accounts.check;
@@ -56,7 +56,8 @@ pub mod cashiers_check {
         };
         let cpi_program = ctx.accounts.token_program.clone();
         let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, signer);
-        token::transfer(cpi_ctx, ctx.accounts.check.amount)?;
+        // token::transfer(cpi_ctx, ctx.accounts.check.amount)?;
+        token::transfer(&ctx.accounts.vault, &ctx.accounts.to, &ctx.accounts.check_signer, Some(signer), ctx.accounts.check.amount)?;
         // Burn the check for one time use.
         ctx.accounts.check.burned = true;
         Ok(())
@@ -76,7 +77,8 @@ pub mod cashiers_check {
         };
         let cpi_program = ctx.accounts.token_program.clone();
         let cpi_ctx = CpiContext::new_with_signer(cpi_program, cpi_accounts, signer);
-        token::transfer(cpi_ctx, ctx.accounts.check.amount)?;
+        // token::transfer(cpi_ctx, ctx.accounts.check.amount)?;
+        token::transfer(&ctx.accounts.vault, &ctx.accounts.from, &ctx.accounts.check_signer, None, ctx.accounts.check.amount)?;
         ctx.accounts.check.burned = true;
         Ok(())
     }


### PR DESCRIPTION
To address #2586 

Question: would the maintainers prefer this as an update over the existing interfaces (less code to maintain but non-backwards-compatible) or as new additional functions (more code but backwards-compatible)?