### PR TITLE
ts: Add missing IDL types

### DIFF
--- a/tests/idl/tests/generics.ts
+++ b/tests/idl/tests/generics.ts
@@ -1,0 +1,19 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Idl } from "@coral-xyz/anchor";
+import { expect } from "chai";
+
+import { Generics, IDL } from "../target/types/generics";
+
+describe("Generics", () => {
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  /**
+   * Checks if the IDL produced by Anchor CLI is compatible with the TypeScript
+   * `Idl` type. Detects a potential mismatch between Rust and TypeScript IDL
+   * definitions.
+   */
+  it("Raw IDL", () => {
+    const idl: Idl = IDL;
+    expect(idl).to.not.be.undefined;
+  });
+});

--- a/ts/packages/anchor/src/idl.ts
+++ b/ts/packages/anchor/src/idl.ts
@@ -139,7 +139,10 @@ export type IdlType =
   | IdlTypeOption
   | IdlTypeCOption
   | IdlTypeVec
-  | IdlTypeArray;
+  | IdlTypeArray
+  | IdlTypeGenericLenArray
+  | IdlTypeGeneric
+  | IdlTypeDefinedWithTypeArgs;
 
 // User defined type.
 export type IdlTypeDefined = {
@@ -160,6 +163,35 @@ export type IdlTypeVec = {
 
 export type IdlTypeArray = {
   array: [idlType: IdlType, size: number];
+};
+
+export type IdlTypeGenericLenArray = {
+  genericLenArray: [idlType: IdlType, generic: string];
+};
+
+export type IdlTypeGeneric = {
+  generic: string;
+};
+
+export type IdlTypeDefinedWithTypeArgs = {
+  definedWithTypeArgs: { name: string; args: IdlTypeDefinedTypeArg[] };
+};
+
+export type IdlTypeDefinedTypeArg =
+  | IdlTypeDefinedTypeArgGeneric
+  | IdlTypeDefinedTypeArgValue
+  | IdlTypeDefinedTypeArgType;
+
+export type IdlTypeDefinedTypeArgGeneric = {
+  generic: string;
+};
+
+export type IdlTypeDefinedTypeArgValue = {
+  value: string;
+};
+
+export type IdlTypeDefinedTypeArgType = {
+  type: IdlType;
 };
 
 export type IdlEnumVariant = {


### PR DESCRIPTION
The following new IDL types were introduced in #2011:

* `GenericLenArray`
* `Generic`
* `DefinedWithTypeArgs`

Usage of these types was leading to incompatibility of the IDL with the TypeScript `IdlType`.

Fixes: #2687