### PR TITLE
fix: use unwrap instead of expect

### DIFF
--- a/lang/syn/src/idl/parse/file.rs
+++ b/lang/syn/src/idl/parse/file.rs
@@ -270,7 +270,7 @@ fn parse_account_derives(ctx: &CrateContext) -> HashMap<String, AccountsStruct> 
         .filter_map(|i_strct| {
             for attr in &i_strct.attrs {
                 if attr.path.is_ident("derive") && attr.tokens.to_string().contains(DERIVE_NAME) {
-                    let strct = accounts::parse(i_strct).expect("Code not parseable");
+                    let strct = accounts::parse(i_strct).unwrap();
                     return Some((strct.ident.to_string(), strct));
                 }
             }


### PR DESCRIPTION
## Problem

Issue:  #683 

## Solution 

If error, use unwrap() instead of expect(). 