### PR TITLE
impl signer now includes deref impl signer

### DIFF
--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -21,7 +21,7 @@ impl<'a> EventUnsubscriber<'a> {
     }
 }
 
-impl<C: Deref<Target = impl Signer> + Clone> Program<C> {
+impl<C: Signer + Clone> Program<C> {
     pub fn new(program_id: Pubkey, cfg: Config<C>) -> Result<Self, ClientError> {
         let rt: tokio::runtime::Runtime = Builder::new_multi_thread().enable_all().build()?;
 
@@ -70,7 +70,7 @@ impl<C: Deref<Target = impl Signer> + Clone> Program<C> {
     }
 }
 
-impl<'a, C: Deref<Target = impl Signer> + Clone> RequestBuilder<'a, C> {
+impl<'a, C: Signer + Clone> RequestBuilder<'a, C> {
     pub fn from(
         program_id: Pubkey,
         cluster: &str,


### PR DESCRIPTION
Now that `Signer` is implemented for all `Deref<Target = impl Signer>` within `solana-sdk`, we can remove this from the client without introducing breaking changes. This simplifies the code and allows `rust-analyzer` to better infer types.