### PR TITLE
syn: relax entry 'info lifetime for compat. with solana-program-test

### DIFF
--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -47,14 +47,14 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         ///
         /// The `entry` function here, defines the standard entry to a Solana
         /// program, where execution begins.
-        pub fn entry<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>], data: &[u8]) -> anchor_lang::solana_program::entrypoint::ProgramResult {
+        pub fn entry<'info>(program_id: &Pubkey, accounts: &[AccountInfo<'info>], data: &[u8]) -> anchor_lang::solana_program::entrypoint::ProgramResult {
             try_entry(program_id, accounts, data).map_err(|e| {
                 e.log();
                 e.into()
             })
         }
 
-        fn try_entry<'info>(program_id: &Pubkey, accounts: &'info [AccountInfo<'info>], data: &[u8]) -> anchor_lang::Result<()> {
+        fn try_entry<'info>(program_id: &Pubkey, accounts: &[AccountInfo<'info>], data: &[u8]) -> anchor_lang::Result<()> {
             #[cfg(feature = "anchor-debug")]
             {
                 msg!("anchor-debug is active");


### PR DESCRIPTION
This PR removes the `'info` lifetime constraint from the `AccountInfo` slice.

This change was necessary for passing Anchor's `program::entry` to the `solana-test-program`'s [`ProgramTest::add_program`](https://docs.rs/solana-program-test/latest/solana_program_test/struct.ProgramTest.html#method.add_program) method.

Here's a sample of the lifetime mismatch, before this PR's changes: 
```
error[E0308]: mismatched types
   --> my_program/tests/integration.rs:23:65
    |
23  |     program.add_program("test-program", my_program::ID, processor!(my_program::entry));
    |                                                      -----------^^^^^^^^^^^^^^-
    |                                                      |          |
    |                                                      |          one type is more general than the other
    |                                                      arguments to this function are incorrect
    |
    = note: expected fn pointer `for<'a, 'b, 'c, 'd> fn(&'a Pubkey, &'b [AccountInfo<'c>], &'d [u8]) -> Result<_, _>`
                  found fn item `for<'info, 'a, 'b> fn(&'a Pubkey, &'info [AccountInfo<'info>], &'b [u8]) -> Result<_, _> {entry}`
note: function defined here
   --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/solana-program-test-1.17.6/src/lib.rs:101:8
    |
101 | pub fn invoke_builtin_function(
    |    
```