### PR TITLE
lang: add E type argument to Result type alias

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -65,7 +65,7 @@ pub use anchor_attribute_event::{emit_cpi, event_cpi};
 #[cfg(feature = "idl-build")]
 pub use anchor_syn::{self, idl::build::IdlBuild};
 
-pub type Result<T> = std::result::Result<T, error::Error>;
+pub type Result<T, E = error::Error> = std::result::Result<T, E>;
 
 /// A data structure of validated accounts that can be deserialized from the
 /// input to a Solana program. Implementations of this trait should perform any


### PR DESCRIPTION
Considering that Result is included in Anchor’s prelude, it’s quite
annoying when one suddenly needs to use Result with a different error
than Anchor’s Error (i.e. use the symbol `Result` like the actual Rust
Result type).

Add E type argument to Anchar’s Result type-alias so that the symbol
can continue to be used like in any Rust code even when someone
imports Anchor’s prelude.

Specify E’s default value to Anchor’s Error so existing Anchor-based
code can continue using the alias as before.
