### PR TITLE
lang: Fix account `try_from` usage

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -393,9 +393,10 @@ pub mod prelude {
         context::Context, context::CpiContext, declare_id, emit, err, error, event, program,
         require, require_eq, require_gt, require_gte, require_keys_eq, require_keys_neq,
         require_neq, solana_program::bpf_loader_upgradeable::UpgradeableLoaderState, source,
-        system_program::System, zero_copy, AccountDeserialize, AccountSerialize, Accounts,
-        AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Id, InitSpace, Key,
-        Lamports, Owner, ProgramData, Result, Space, ToAccountInfo, ToAccountInfos, ToAccountMetas,
+        system_program::System, try_from, zero_copy, AccountDeserialize, AccountSerialize,
+        Accounts, AccountsClose, AccountsExit, AnchorDeserialize, AnchorSerialize, Id, InitSpace,
+        Key, Lamports, Owner, ProgramData, Result, Space, ToAccountInfo, ToAccountInfos,
+        ToAccountMetas,
     };
     pub use anchor_attribute_error::*;
     pub use borsh;
@@ -725,5 +726,12 @@ macro_rules! source {
             filename: file!(),
             line: line!(),
         }
+    };
+}
+
+#[macro_export]
+macro_rules! try_from {
+    ($ty: ty, $acc: expr) => {
+        <$ty>::try_from(unsafe { core::mem::transmute::<_, &AccountInfo<'info>>($acc.as_ref()) })
     };
 }

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -732,6 +732,6 @@ macro_rules! source {
 #[macro_export]
 macro_rules! try_from {
     ($ty: ty, $acc: expr) => {
-        <$ty>::try_from(unsafe { core::mem::transmute::<_, &AccountInfo<'info>>($acc.as_ref()) })
+        <$ty>::try_from(unsafe { core::mem::transmute::<_, &AccountInfo<'_>>($acc.as_ref()) })
     };
 }

--- a/tests/misc/Anchor.toml
+++ b/tests/misc/Anchor.toml
@@ -9,6 +9,7 @@ misc = "3TEqcc8xhrhdspwbvoamUJe2borm4Nr72JxL66k6rgrh"
 misc_optional = "FNqz6pqLAwvMSds2FYjR4nKV3moVpPNtvkfGFrqLKrgG"
 overflow_checks = "overf1owChecks11111111111111111111111111111"
 remaining_accounts = "RemainingAccounts11111111111111111111111111"
+try_from = "TryFrom111111111111111111111111111111111111"
 
 [workspace]
 exclude = ["programs/shared"]

--- a/tests/misc/programs/try-from/Cargo.toml
+++ b/tests/misc/programs/try-from/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "try-from"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "try_from"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/misc/programs/try-from/Xargo.toml
+++ b/tests/misc/programs/try-from/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/misc/programs/try-from/src/lib.rs
+++ b/tests/misc/programs/try-from/src/lib.rs
@@ -11,8 +11,8 @@ pub mod try_from {
         Ok(())
     }
 
-    pub fn try_from(ctx: Context<TryFrom>, field: u8) -> Result<()> {
-        let my_account = Account::<MyAccount>::try_from(&ctx.accounts.my_account)?;
+    pub fn try_from<'info>(ctx: Context<TryFrom>, field: u8) -> Result<()> {
+        let my_account = try_from!(Account::<MyAccount>, ctx.accounts.my_account)?;
         msg!("Field: {}", my_account.field);
         require_eq!(my_account.field, field);
 

--- a/tests/misc/programs/try-from/src/lib.rs
+++ b/tests/misc/programs/try-from/src/lib.rs
@@ -1,0 +1,40 @@
+use anchor_lang::prelude::*;
+
+declare_id!("TryFrom111111111111111111111111111111111111");
+
+#[program]
+pub mod try_from {
+    use super::*;
+
+    pub fn init(ctx: Context<Init>, field: u8) -> Result<()> {
+        ctx.accounts.my_account.field = field;
+        Ok(())
+    }
+
+    pub fn try_from(ctx: Context<TryFrom>, field: u8) -> Result<()> {
+        let my_account = Account::<MyAccount>::try_from(&ctx.accounts.my_account)?;
+        msg!("Field: {}", my_account.field);
+        require_eq!(my_account.field, field);
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Init<'info> {
+    #[account(init, payer = payer, space = 8 + 1)]
+    pub my_account: Account<'info, MyAccount>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct TryFrom<'info> {
+    pub my_account: UncheckedAccount<'info>,
+}
+
+#[account]
+pub struct MyAccount {
+    pub field: u8,
+}

--- a/tests/misc/programs/try-from/src/lib.rs
+++ b/tests/misc/programs/try-from/src/lib.rs
@@ -11,7 +11,7 @@ pub mod try_from {
         Ok(())
     }
 
-    pub fn try_from<'info>(ctx: Context<TryFrom>, field: u8) -> Result<()> {
+    pub fn try_from(ctx: Context<TryFrom>, field: u8) -> Result<()> {
         let my_account = try_from!(Account::<MyAccount>, ctx.accounts.my_account)?;
         msg!("Field: {}", my_account.field);
         require_eq!(my_account.field, field);

--- a/tests/misc/tests/try-from/Test.toml
+++ b/tests/misc/tests/try-from/Test.toml
@@ -1,0 +1,2 @@
+[scripts]
+test = "yarn run ts-mocha -t 1000000 ./tests/try-from/*.ts"

--- a/tests/misc/tests/try-from/try-from.ts
+++ b/tests/misc/tests/try-from/try-from.ts
@@ -1,0 +1,28 @@
+import * as anchor from "@coral-xyz/anchor";
+
+import { TryFrom, IDL } from "../../target/types/try_from";
+
+describe(IDL.name, () => {
+  anchor.setProvider(anchor.AnchorProvider.env());
+
+  const program = anchor.workspace.TryFrom as anchor.Program<TryFrom>;
+
+  it("Can use `try_from`", async () => {
+    const myAccountKp = anchor.web3.Keypair.generate();
+    const FIELD = 5;
+    await program.methods
+      .init(FIELD)
+      .accounts({
+        myAccount: myAccountKp.publicKey,
+      })
+      .signers([myAccountKp])
+      .rpc();
+
+    await program.methods
+      .tryFrom(FIELD)
+      .accounts({
+        myAccount: myAccountKp.publicKey,
+      })
+      .rpc();
+  });
+});


### PR DESCRIPTION
### Problem

Using `try_from` in the instruction handler:

```rs
pub fn try_from(ctx: Context<TryFrom>) -> Result<()> {
    Account::<MyAccount>::try_from(&ctx.accounts.my_account)?;
    Ok(())
}
```

results in:

```
error: lifetime may not live long enough
  --> programs/try-from/src/lib.rs:15:9
   |
14 |     pub fn try_from(ctx: Context<TryFrom>) -> Result<()> {
   |                     ---
   |                     |
   |                     has type `anchor_lang::context::Context<'_, '1, '_, '_, TryFrom<'_>>`
   |                     has type `anchor_lang::context::Context<'_, '_, '_, '_, TryFrom<'2>>`
15 |         Account::<MyAccount>::try_from(&ctx.accounts.my_account)?;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
```

### Details 

Ideally, the fix would be limited to Anchor internals without needing a breaking change to the users. However, this is difficult to achieve because https://github.com/coral-xyz/anchor/pull/2656 added the same lifetime requirement for the `AccountInfo` references:

https://github.com/coral-xyz/anchor/blob/c93b33a27ef68f7380e573711b53bdda81b3632d/lang/src/accounts/account.rs#L226-L229

The `info: &'info AccountInfo<'info>` part is incompatible with Anchor's codegen because accounts passed to the context has a shorter lifetime than the `AccountInfo`'s internal lifetime. While the lifetime annotations are incorrect based on Anchor's codegen, it's also not accidental. To properly annotate these lifetimes, we'd have to add another lifetime to the `Account` type(and all other account types) which would significantly hinder the developer experience since it's a public API.

In short, this problem is caused by annoting the same lifetimes in places where it's technically incorrect but we're doing so in order to not have multiple lifetimes in account types.

One possible solution for this problem is to elide the lifetimes by using [`core::mem::transmute`](https://doc.rust-lang.org/core/mem/fn.transmute.html). Using `transmute` is heavily discouraged but my understanding is, this should be safe to do in this case because both `accounts` lifetime and the `AccountInfo`'s internal lifetime live longer than the user's instruction handler.

### Usage

```rs
try_from!(Account::<MyAccount>, ctx.accounts.my_account)
```


### Summary of changes

- Add a test program for `try_from` usage
- Add `try_from!` macro