### PR TITLE
Add `solana-program-test` compatibility test in CI 

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -365,6 +365,49 @@ jobs:
       # - run: cd "$(mktemp -d)" && anchor init hello-anchor && cd hello-anchor && yarn link @coral-xyz/anchor && yarn && anchor test && yarn lint:fix
       # - uses: ./.github/actions/git-diff/
 
+  test-anchor-compatibility:
+    needs: setup-anchor-cli
+    name: Test Anchor Compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup/
+      - uses: ./.github/actions/setup-ts/
+      - uses: ./.github/actions/setup-solana/
+      - uses: actions/cache@v3
+        if: ${{ env.CACHE != 'false' }}
+        name: Cache Cargo registry + index
+        id: cache-anchor
+        with:
+          path: ${{ env.CARGO_CACHE_PATH }}
+          key: cargo-${{ runner.os }}-${{ env.CARGO_PROFILE }}-anchor-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ANCHOR_BINARY_NAME }}
+          path: ~/.cargo/bin/
+      - run: chmod +x ~/.cargo/bin/anchor
+      - name: Run Compatibility Tests
+        # TODO: Remove continue-on-error once https://github.com/coral-xyz/anchor/pull/2711 is resolved
+        continue-on-error: true
+        run: |
+          cd tests/compatibility-testing
+          test_output=$(cargo test --package compatibility-testing --test solana_program_test entrypoint_lifetime 2>&1) || test_exit_code=$?
+          echo "$test_output"
+
+          # Success exit code
+          if [ "$test_exit_code" -eq 0 ]; then
+            echo "solana_program_test entrypoint_lifetime compatibility test passed with exit code: $test_exit_code"
+          # Unrecoverable error exit code
+          elif [ "$test_exit_code" -eq 101 ]; then
+            echo "solana_program_test entrypoint_lifetime compatibility test failed with exit code: $test_exit_code"
+            exit 1
+          else
+            echo "Unexpected exit code: $test_exit_code"
+            exit 1
+          fi
+      - uses: ./.github/actions/git-diff/
+
   test-programs:
     needs: setup-anchor-cli
     name: Test ${{ matrix.node.path }}

--- a/tests/compatibility-testing/.prettierignore
+++ b/tests/compatibility-testing/.prettierignore
@@ -1,0 +1,8 @@
+
+.anchor
+.DS_Store
+target
+node_modules
+dist
+build
+test-ledger

--- a/tests/compatibility-testing/Anchor.toml
+++ b/tests/compatibility-testing/Anchor.toml
@@ -1,0 +1,18 @@
+[toolchain]
+
+[features]
+seeds = false
+skip-lint = false
+
+[programs.localnet]
+compatibility_testing = "DhFkMBzU3BqvcWuUZkFQR8QajQsiGYLPrhCh5BQBgmkg"
+
+[registry]
+url = "https://api.apr.dev"
+
+[provider]
+cluster = "Localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/compatibility-testing/Cargo.toml
+++ b/tests/compatibility-testing/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+members = [
+    "programs/*"
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1

--- a/tests/compatibility-testing/migrations/deploy.ts
+++ b/tests/compatibility-testing/migrations/deploy.ts
@@ -1,0 +1,12 @@
+// Migrations are an early feature. Currently, they're nothing more than this
+// single deploy script that's invoked from the CLI, injecting a provider
+// configured from the workspace's Anchor.toml.
+
+const anchor = require("@coral-xyz/anchor");
+
+module.exports = async function (provider) {
+  // Configure client to use the provider.
+  anchor.setProvider(provider);
+
+  // Add your deploy script here.
+};

--- a/tests/compatibility-testing/package.json
+++ b/tests/compatibility-testing/package.json
@@ -1,0 +1,19 @@
+{
+    "scripts": {
+        "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
+        "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check"
+    },
+    "dependencies": {
+        "@coral-xyz/anchor": "^0.29.0"
+    },
+    "devDependencies": {
+        "chai": "^4.3.4",
+        "mocha": "^9.0.3",
+        "ts-mocha": "^10.0.0",
+        "@types/bn.js": "^5.1.0",
+        "@types/chai": "^4.3.0",
+        "@types/mocha": "^9.0.0",
+        "typescript": "^4.3.5",
+        "prettier": "^2.6.2"
+    }
+}

--- a/tests/compatibility-testing/programs/compatibility-testing/Cargo.toml
+++ b/tests/compatibility-testing/programs/compatibility-testing/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "compatibility-testing"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "compatibility_testing"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }
+solana-program-test = ">=1.16, <1.18"

--- a/tests/compatibility-testing/programs/compatibility-testing/Xargo.toml
+++ b/tests/compatibility-testing/programs/compatibility-testing/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/compatibility-testing/programs/compatibility-testing/src/lib.rs
+++ b/tests/compatibility-testing/programs/compatibility-testing/src/lib.rs
@@ -1,0 +1,15 @@
+use anchor_lang::prelude::*;
+
+declare_id!("DhFkMBzU3BqvcWuUZkFQR8QajQsiGYLPrhCh5BQBgmkg");
+
+#[program]
+pub mod compatibility_testing {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize {}

--- a/tests/compatibility-testing/programs/compatibility-testing/tests/solana_program_test.rs
+++ b/tests/compatibility-testing/programs/compatibility-testing/tests/solana_program_test.rs
@@ -1,0 +1,10 @@
+use solana_program_test::{processor, ProgramTest};
+
+#[test]
+fn entrypoint_lifetime() {
+    let _pt = ProgramTest::new(
+        "compatibility_testing",
+        compatibility_testing::id(),
+        processor!(compatibility_testing::entry),
+    );
+}

--- a/tests/compatibility-testing/tsconfig.json
+++ b/tests/compatibility-testing/tsconfig.json
@@ -1,0 +1,11 @@
+{
+            "compilerOptions": {
+              "types": ["mocha", "chai"],
+              "typeRoots": ["./node_modules/@types"],
+              "lib": ["es2015"],
+              "module": "commonjs",
+              "target": "es6",
+              "esModuleInterop": true
+            }
+          }
+          

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,6 +14,7 @@
     "cfo",
     "chat",
     "composite",
+    "compatibility-testing",
     "custom-coder",
     "errors",
     "escrow",


### PR DESCRIPTION
Closes #2738

This PR adds the `tests/compatibility-testing` package which contains a simple test that checks the entrypoint lifetime compatibility between `anchor-lang` and `solana-program-test`.

**Executing compatibility tests (currently failing)**
1.  clone repo and switch to this branch
2. `cd tests/compatibility-testing`
3.  `cargo test --package compatibility-testing --test solana_program_test entrypoint_lifetime`

**Verifying compatibility tests pass before #2656** 
1. clone repo and switch to this branch
2. `git checkout -b temp-branch`
3. `git checkout 243ab7573865a7296dd2af1153f44bffbf488458`
4. `git checkout temp-branch -- tests/compatibility-testing`
5. `cd tests/compatibility-testing`
6. `cargo test --package compatibility-testing --test solana_program_test entrypoint_lifetime`

