### PR TITLE
Update ahash to 0.8.7

### DIFF
--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -64,4 +64,4 @@ thiserror = "1"
 getrandom = { version = "0.2", features = ["custom"] }
 
 # TODO: Remove once https://github.com/solana-labs/solana/issues/33504 is resolved.
-ahash = "=0.8.6"
+ahash = "=0.8.7"


### PR DESCRIPTION
Fresh installation of anchor was breaking, this should fix it.

### Problem
```

error[E0635]: unknown feature stdsimd
  --> /home/mohit/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.6/src/lib.rs:99:42
   |
99 | #![cfg_attr(feature = "stdsimd", feature(stdsimd))]
   |                                          ^^^^^^^`
```

### Solution
https://github.com/tkaitchuck/aHash/issues/200
https://github.com/tkaitchuck/aHash/pull/183