### PR TITLE
Remove yarn dependency

### DIFF
--- a/cli/src/checks.rs
+++ b/cli/src/checks.rs
@@ -74,7 +74,7 @@ pub fn check_anchor_version(cfg: &WithPath<Config>) -> Result<()> {
             "WARNING: `@coral-xyz/anchor` version({ver}) and the current CLI version\
                 ({cli_version}) don't match.\n\n\t\
                 This can lead to unwanted behavior. To fix, upgrade the package by running:\n\n\t\
-                yarn upgrade @coral-xyz/anchor@{cli_version}\n"
+                npm update @coral-xyz/anchor@{cli_version}\n"
         );
     }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -947,11 +947,7 @@ fn init(
         &program_id.to_string(),
     )?;
 
-    let yarn_result = install_node_modules("yarn")?;
-    if !yarn_result.status.success() {
-        println!("Failed yarn install will attempt to npm install");
-        install_node_modules("npm")?;
-    }
+    install_node_modules()?;
 
     if !no_git {
         let git_result = std::process::Command::new("git")
@@ -970,21 +966,21 @@ fn init(
     Ok(())
 }
 
-fn install_node_modules(cmd: &str) -> Result<std::process::Output> {
+fn install_node_modules() -> Result<std::process::Output> {
     if cfg!(target_os = "windows") {
         std::process::Command::new("cmd")
-            .arg(format!("/C {cmd} install"))
+            .arg(format!("/C npm install"))
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()
-            .map_err(|e| anyhow::format_err!("{} install failed: {}", cmd, e.to_string()))
+            .map_err(|e| anyhow::format_err!("npm install failed: {}", e.to_string()))
     } else {
-        std::process::Command::new(cmd)
+        std::process::Command::new("npm")
             .arg("install")
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()
-            .map_err(|e| anyhow::format_err!("{} install failed: {}", cmd, e.to_string()))
+            .map_err(|e| anyhow::format_err!("npm install failed: {}", e.to_string()))
     }
 }
 
@@ -3890,7 +3886,7 @@ fn migrate(cfg_override: &ConfigOverride) -> Result<()> {
                 rust_template::deploy_ts_script_host(&url, &module_path.display().to_string());
             fs::write(deploy_ts, deploy_script_host_str)?;
 
-            std::process::Command::new("yarn")
+            std::process::Command::new("npm")
                 .args([
                     "run",
                     "ts-node",

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -650,16 +650,16 @@ impl TestTemplate {
         match &self {
             Self::Mocha => {
                 if js {
-                    "yarn run mocha -t 1000000 tests/"
+                    "npm run mocha -t 1000000 tests/"
                 } else {
-                    "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+                    "npm run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
                 }
             }
             Self::Jest => {
                 if js {
-                    "yarn run jest"
+                    "npm run jest"
                 } else {
-                    "yarn run jest --preset ts-jest"
+                    "npm run jest --preset ts-jest"
                 }
             }
             Self::Rust => "cargo test",


### PR DESCRIPTION
 - Changes current behavior (require warn, try yarn, warn if yarn is missing, use npm) to just using npm
 - Use npm in test scripts too
 - Update 'mismatched version' error message to also use npm
 
This PR doesn't change yarn being used to build Anchor itself. 