### PR TITLE
lang: Make program ID `const` instead of `static` in `declare_program!`

### DIFF
--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -114,10 +114,10 @@ fn gen_id(idl: &Idl) -> proc_macro2::TokenStream {
 
     quote! {
         #[doc = #doc]
-        pub static ID: Pubkey = __ID;
+        pub const ID: Pubkey = __ID;
 
         /// The name is intentionally prefixed with `__` in order to reduce to possibility of name
         /// clashes with the crate's `ID`.
-        static __ID: Pubkey = Pubkey::new_from_array([#(#address_bytes,)*]);
+        const __ID: Pubkey = Pubkey::new_from_array([#(#address_bytes,)*]);
     }
 }


### PR DESCRIPTION
Currently the program ID is exported as `static`. Exporting it as `const` would allow for using it inside of `const` functions for compile time checks and derivations (e.g. https://github.com/cavemanloverboy/const-crypto) without much downside.

This change could potentially make sense inside `declare_id!` as well, but holding off from this for now, as I don't know to what extent this might break backward compatibility. However, if we consider this as a breaking change inside of `declare_program!` anyway, I'd opt for extending this to also include this change inside `declare_id!`.