### PR TITLE
Remove empty tests

### DIFF
--- a/tests/misc/programs/shared/Cargo.toml
+++ b/tests/misc/programs/shared/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "shared"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/tests/misc/programs/shared/src/lib.rs
+++ b/tests/misc/programs/shared/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/tests/typescript/programs/shared/Cargo.toml
+++ b/tests/typescript/programs/shared/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "shared"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/tests/typescript/programs/shared/src/lib.rs
+++ b/tests/typescript/programs/shared/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/tests/zero-copy/programs/shared/Cargo.toml
+++ b/tests/zero-copy/programs/shared/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "shared"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/tests/zero-copy/programs/shared/src/lib.rs
+++ b/tests/zero-copy/programs/shared/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
This is prompted by warnings I get whenever I build Anchor programs:

    warning: skipping duplicate package `shared` found at `…/.cargo/git/checkouts/anchor-5212c2606adb64eb/788c61c/tests/zero-copy/programs/shared`
    warning: skipping duplicate package `shared` found at `…/.cargo/git/checkouts/anchor-5212c2606adb64eb/788c61c/tests/typescript/programs/shared`

I’m not completely clear on the reasons but I figured since the tests don’t actually do anything they can be removed and hopefully the warnings will go away.

There are three more warnings I’m seeing, but I’ve no idea what to do about those:

    warning: skipping duplicate package `relations-derivation` found at `…/.cargo/git/checkouts/anchor-5212c2606adb64eb/788c61c/tests/idl/programs/relations-derivation`
    warning: skipping duplicate package `docs` found at `…/.cargo/git/checkouts/anchor-5212c2606adb64eb/788c61c/tests/docs/programs/docs`
    warning: skipping duplicate package `swap` found at `…/.cargo/git/checkouts/anchor-5212c2606adb64eb/788c61c/tests/swap/programs/swap`
