### PR TITLE
Do not build anchor syn for the Solana target

### DIFF
--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg(not(target_os = "solana"))]
 
 pub mod codegen;
 pub mod parser;


### PR DESCRIPTION
Function inside `anchor/lang/syn` only serve for code generation, but are also built for Solana programs, leading to spurious stack error warnings.