### PR TITLE
[Breaking Change]: fix(client): Update `signer` method to accept a slice of signers

### DIFF
--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -138,8 +138,10 @@ impl<'a, C: Deref<Target = impl Signer> + Clone> RequestBuilder<'a, C, Box<dyn S
     }
 
     #[must_use]
-    pub fn signer<T: Signer + 'a>(mut self, signer: T) -> Self {
-        self.signers.push(Box::new(signer));
+    pub fn signers<T: Signer + Clone + 'a>(mut self, signers: &[T]) -> Self {
+        for signer in signers {
+            self.signers.push(Box::new(signer.clone()));
+        }
         self
     }
 


### PR DESCRIPTION
I have refactored the `signer` method to accept a slice of signers for multiple signers in a single call. This change simplifies the API by reducing redundancy.

Now we can do:

```rust
.signers(&[payer, bid, ask])
.send()
```

Instead of:

```rust
.signer(&payer)
.signer(&bid)
.signer(&ask)
.send()
```