### PR TITLE
lang: Fix anchor init template error 

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -59,7 +59,7 @@ pub mod {} {{
     use super::*;
 
     pub fn initialize(ctx: Context<Initialize>) -> Result<()> {{
-        msg!("Greetings from: {{:?}}", ctx.program_id);
+        msg!("Greetings from: {:?}", ctx.program_id);
         Ok(())
     }}
 }}
@@ -143,7 +143,7 @@ pub use initialize::*;
 pub struct Initialize {}
 
 pub fn handler(ctx: Context<Initialize>) -> Result<()> {
-    msg!("Greetings from: {{:?}}", ctx.program_id);
+    msg!("Greetings from: {:?}", ctx.program_id);
     Ok(())
 }
 "#


### PR DESCRIPTION
machine
rust version: 1.80.1
anchor version: 0.30.1
arch: macOS Sonoma arm64

recover step:

`anchor init program-name`
`anchor test`

then

```
error: argument never used
 --> programs/program-name/src/instructions/initialize.rs:7:36
  |
7 |     msg!("Greetings from: {{:?}}", ctx.program_id);
  |          ------------------------  ^^^^^^^^^^^^^^ argument never used
  |          |
  |          formatting specifier missing

warning: unused import: `state::*`
  --> programs/program-name/src/lib.rs:10:9
   |
10 | pub use state::*;
   |         ^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `program-name` (lib) generated 1 warning
error: could not compile `program-name` (lib) due to previous error; 1 warning emitted
```
