### PR TITLE
cli: fix ts test files path parse error

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -620,7 +620,7 @@ impl TestTemplate {
                 if js {
                     "yarn run mocha -t 1000000 tests/"
                 } else {
-                    "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+                    "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"
                 }
             }
             Self::Jest => {

--- a/docs/src/pages/docs/manifest.md
+++ b/docs/src/pages/docs/manifest.md
@@ -23,7 +23,7 @@ Example:
 
 ```toml
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"
 ```
 
 ## registry

--- a/examples/tutorial/basic-5/Anchor.toml
+++ b/examples/tutorial/basic-5/Anchor.toml
@@ -6,4 +6,4 @@ wallet = "~/.config/solana/id.json"
 basic_5 = "DuT6R8tQGYa8ACYXyudFJtxDppSALLcmK39b7918jeSC"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/anchor-cli-account/Anchor.toml
+++ b/tests/anchor-cli-account/Anchor.toml
@@ -6,6 +6,6 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"
 
 [features]

--- a/tests/anchor-cli-idl/Anchor.toml
+++ b/tests/anchor-cli-idl/Anchor.toml
@@ -10,4 +10,4 @@ cluster = "localnet"
 wallet = "./keypairs/deployer-keypair.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/auction-house/Anchor.toml
+++ b/tests/auction-house/Anchor.toml
@@ -15,7 +15,7 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"
 
 [[test.genesis]]
 address = "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"

--- a/tests/bpf-upgradeable-state/Anchor.toml
+++ b/tests/bpf-upgradeable-state/Anchor.toml
@@ -6,4 +6,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/cpi-returns/Anchor.toml
+++ b/tests/cpi-returns/Anchor.toml
@@ -10,4 +10,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/custom-coder/Anchor.toml
+++ b/tests/custom-coder/Anchor.toml
@@ -8,4 +8,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/custom-discriminator/Anchor.toml
+++ b/tests/custom-discriminator/Anchor.toml
@@ -17,4 +17,4 @@ cluster = "Localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/declare-program/Anchor.toml
+++ b/tests/declare-program/Anchor.toml
@@ -7,4 +7,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/floats/Anchor.toml
+++ b/tests/floats/Anchor.toml
@@ -6,4 +6,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/idl/Anchor.toml
+++ b/tests/idl/Anchor.toml
@@ -16,4 +16,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/lazy-account/Anchor.toml
+++ b/tests/lazy-account/Anchor.toml
@@ -6,4 +6,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/pda-derivation/Anchor.toml
+++ b/tests/pda-derivation/Anchor.toml
@@ -12,4 +12,4 @@ pda_derivation = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 members = ["programs/pda-derivation"]
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/pyth/Anchor.toml
+++ b/tests/pyth/Anchor.toml
@@ -6,6 +6,6 @@ wallet = "~/.config/solana/id.json"
 pyth = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"
 
 [features]

--- a/tests/realloc/Anchor.toml
+++ b/tests/realloc/Anchor.toml
@@ -9,4 +9,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/relations-derivation/Anchor.toml
+++ b/tests/relations-derivation/Anchor.toml
@@ -12,4 +12,4 @@ relations_derivation = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 members = ["programs/relations-derivation"]
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/solang/Anchor.toml
+++ b/tests/solang/Anchor.toml
@@ -10,4 +10,4 @@ cluster = "Localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/spl/metadata/Anchor.toml
+++ b/tests/spl/metadata/Anchor.toml
@@ -6,4 +6,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/typescript/Anchor.toml
+++ b/tests/typescript/Anchor.toml
@@ -9,4 +9,4 @@ typescript = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 members = ["programs/typescript"]
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"

--- a/tests/validator-clone/Anchor.toml
+++ b/tests/validator-clone/Anchor.toml
@@ -8,7 +8,7 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'"
 
 [test]
 startup_wait = 20000


### PR DESCRIPTION
Has many testing file when build project. 

Template code
- `anchor test`  <=>  `yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts`

Real commands
- `anchor test`  <=>  `yarn run ts-mocha -p ./tsconfig.json -t 1000000 'tests/**/*.ts'`

Errors sometime
- `yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/shared/utils.ts` not `tests/**/*.ts`

