### PR TITLE
fix: separate PDA handling for multiple token programs in escrow tests

### DIFF
--- a/tests/escrow/tests/escrow.ts
+++ b/tests/escrow/tests/escrow.ts
@@ -116,6 +116,16 @@ describe("escrow", () => {
       });
 
       it("Initialize escrow", async () => {
+        const [escrowPda, _nonce] = await PublicKey.findProgramAddress(
+          [
+            Buffer.from(anchor.utils.bytes.utf8.encode("escrow")),
+            tokenProgramIdA.toBuffer(),
+          ],
+          program.programId
+        );
+
+        pda = escrowPda;
+
         await program.rpc.initializeEscrow(
           new BN(initializerAmount),
           new BN(takerAmount),
@@ -131,14 +141,6 @@ describe("escrow", () => {
             signers: [escrowAccount],
           }
         );
-
-        // Get the PDA that is assigned authority to token account.
-        const [_pda, _nonce] = await PublicKey.findProgramAddress(
-          [Buffer.from(anchor.utils.bytes.utf8.encode("escrow"))],
-          program.programId
-        );
-
-        pda = _pda;
 
         let _initializerTokenAccountA = await mintA.getAccountInfo(
           initializerTokenAccountA
@@ -229,6 +231,16 @@ describe("escrow", () => {
           [mintAuthority],
           initializerAmount
         );
+
+        const [escrowPda, _nonce] = await PublicKey.findProgramAddress(
+          [
+            Buffer.from(anchor.utils.bytes.utf8.encode("escrow")),
+            tokenProgramIdA.toBuffer(),
+          ],
+          program.programId
+        );
+
+        pda = escrowPda;
 
         await program.rpc.initializeEscrow(
           new BN(initializerAmount),


### PR DESCRIPTION
This PR fixes an issue where the same PDA was being used for both TOKEN_PROGRAM_ID and TOKEN_2022_PROGRAM_ID during escrow tests, which could cause conflicts. The fix involves deriving separate PDAs for each token program, ensuring that the right authority is used based on the token program involved. This resolves potential ownership conflicts when interacting with the escrow state across multiple token programs.