### PR TITLE
Add nvm to installation guide for avm

### DIFF
--- a/docs/src/pages/docs/installation.md
+++ b/docs/src/pages/docs/installation.md
@@ -19,6 +19,10 @@ Go [here](https://docs.solana.com/cli/install-solana-cli-tools) to install Solan
 We also recommend checking out the official [Solana developers page](https://solana.com/developers).
 {% /callout %}
 
+## NVM
+
+Go [here](https://www.freecodecamp.org/news/node-version-manager-nvm-install-guide/) to install nvm, which will allow you to install node and npm.
+
 ## Yarn
 
 Go [here](https://yarnpkg.com/getting-started/install) to install Yarn.


### PR DESCRIPTION
**Problem** 

When following the getting started guide on a fresh system, anchor init results in OS errors, and package.json and tests directory fails to be created. nvm, node, and npm must be listed as dependencies as well in order for anchor init to generate the package.json and tests directory. 

**Solution**

npm is a necessary dependency for avm, so it should be listed alongside the other dependencies, I think.