### PR TITLE
Add UncheckedAccount::account_info

### DIFF
--- a/lang/src/accounts/unchecked_account.rs
+++ b/lang/src/accounts/unchecked_account.rs
@@ -18,6 +18,10 @@ impl<'info> UncheckedAccount<'info> {
     pub fn try_from(acc_info: &'info AccountInfo<'info>) -> Self {
         Self(acc_info)
     }
+
+    pub fn account_info(&self) -> &'info AccountInfo<'info> {
+        self.0
+    }
 }
 
 impl<'info, B> Accounts<'info, B> for UncheckedAccount<'info> {


### PR DESCRIPTION
Provide a workaround for lifetime issue. This function returns `&'info` instead of the shorter lifetime returned by `UncheckedAccount::as_ref`. For how this is used, see https://github.com/metaplex-foundation/mpl-candy-machine/pull/76/commits/1553e2143b041779f4747cfc7ef3f9dbabbac99b .