### PR TITLE
lang: Fix `declare_program!` using non-instruction composite accounts multiple times 

### DIFF
--- a/tests/declare-program/idls/external.json
+++ b/tests/declare-program/idls/external.json
@@ -45,6 +45,52 @@
       "args": []
     },
     {
+      "name": "second_use_of_non_instruction_composite",
+      "discriminator": [
+        103,
+        165,
+        187,
+        198,
+        36,
+        148,
+        158,
+        119
+      ],
+      "accounts": [
+        {
+          "name": "non_instruction_update",
+          "accounts": [
+            {
+              "name": "authority",
+              "signer": true
+            },
+            {
+              "name": "my_account",
+              "writable": true,
+              "pda": {
+                "seeds": [
+                  {
+                    "kind": "account",
+                    "path": "authority"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "program",
+              "address": "Externa111111111111111111111111111111111111"
+            }
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "value",
+          "type": "u32"
+        }
+      ]
+    },
+    {
       "name": "test_compilation_defined_type_param",
       "discriminator": [
         61,

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -35,8 +35,8 @@ pub mod external {
 
     // Test the issue described in https://github.com/coral-xyz/anchor/issues/3349
     pub fn second_use_of_non_instruction_composite(
-        ctx: Context<SecondUseOfNonInstructionComposite>,
-        value: u32,
+        _ctx: Context<SecondUseOfNonInstructionComposite>,
+        _value: u32,
     ) -> Result<()> {
         Ok(())
     }

--- a/tests/declare-program/programs/external/src/lib.rs
+++ b/tests/declare-program/programs/external/src/lib.rs
@@ -33,6 +33,14 @@ pub mod external {
         Ok(())
     }
 
+    // Test the issue described in https://github.com/coral-xyz/anchor/issues/3349
+    pub fn second_use_of_non_instruction_composite(
+        ctx: Context<SecondUseOfNonInstructionComposite>,
+        value: u32,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     // Compilation test for whether a defined type (an account in this case) can be used in `cpi` client.
     pub fn test_compilation_defined_type_param(
         _ctx: Context<TestCompilation>,
@@ -89,6 +97,11 @@ pub struct UpdateComposite<'info> {
 
 #[derive(Accounts)]
 pub struct UpdateNonInstructionComposite<'info> {
+    pub non_instruction_update: NonInstructionUpdate<'info>,
+}
+
+#[derive(Accounts)]
+pub struct SecondUseOfNonInstructionComposite<'info> {
     pub non_instruction_update: NonInstructionUpdate<'info>,
 }
 


### PR DESCRIPTION
#### Problem

Described in https://github.com/coral-xyz/anchor/issues/3349

#### Summary of changes
Use a HashSet to enforce unique naming for account definitions

Resolves #3349