### PR TITLE
feature: Better Windows Support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,17 +66,18 @@ jobs:
 
           if [[ "${RUNNER_OS}" == "Linux" ]]; then
             release_folder="ubuntu-latest"
-          fi
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          elif [[ "${RUNNER_OS}" == "Windows" ]]; then
             binary_extension=".exe"
             release_folder="windows-latest"
-          fi
-          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+          elif [[ "${RUNNER_OS}" == "macOS" ]]; then
             if [[ "${{ matrix.os }}" == "macos-14" ]]; then
               release_folder="macos-m1-latest"
             else
               release_folder="macos-intel-latest"
             fi
+          else
+            echo "unknown value for RUNNER_OS: ${RUNNER_OS}"
+            exit 1
           fi
 
           mkdir -p "${release_folder}"
@@ -84,7 +85,7 @@ jobs:
 
           mv "target/release/anchor${binary_extension}" "${release_folder}"
           mv "target/release/avm${binary_extension}" "${release_folder}"
-          # strip "${release_folder}/*"
+          strip "${release_folder}/*"
 
       - name: Publish Artifacts
         if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,8 +83,8 @@ jobs:
           fi
 
           mkdir -p "${release_folder}"
-          echo "::set-output name=release-folder::${release_folder}"
-          
+          echo "release-folder=${VERSION}" >> "${GITHUB_OUTPUT}"
+
           mv "target/release/anchor${binary_extension}" "${release_folder}"
           mv "target/release/avm${binary_extension}" "${release_folder}"
           # strip "${release_folder}/*"
@@ -93,11 +93,11 @@ jobs:
         if: "!startsWith(github.ref, 'refs/tags/')"
         uses: actions/upload-artifact@v4
         with:
-          name: "anchor-${{ steps.build.outputs.release-folder }}-${{ steps.build.set-version.version }}"
+          name: "anchor-${{ steps.build.outputs.release-folder }}-${{ steps.set-version.outputs.version }}"
           path: "${{ steps.build.outputs.release-folder }}/*"
 
       - name: Release Tags
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,11 +59,11 @@ jobs:
         run: |
           # build avm and anchor separately for now because
           # of the name conflict in avm/anchor and cli/anchor
-          # cargo build --release -p anchor-cli --bin anchor
-          # cargo build --release -p avm --bin avm
-          cargo build --release --bin hello
-          cp "target/release/hello.exe" "target/release/avm.exe"
-          cp "target/release/hello.exe" "target/release/anchor.exe"
+          cargo build --release -p anchor-cli --bin anchor
+          cargo build --release -p avm --bin avm
+          # cargo build --release --bin hello
+          # cp "target/release/hello.exe" "target/release/avm.exe"
+          # cp "target/release/hello.exe" "target/release/anchor.exe"
 
           binary_extension=""
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         os:
           - windows-latest
-          # - ubuntu-latest
-          # - macos-latest
-          # - macos-14
+          - ubuntu-latest
+          - macos-latest
+          - macos-14
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Publish Artifacts
         if: "!startsWith(github.ref, 'refs/tags/')"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: "anchor-${{ steps.build.outputs.release-folder }}-${{ steps.build.set-version.version }}"
           path: "${{ steps.build.outputs.release-folder }}/*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          # - ubuntu-latest
+          # - macos-latest
+          # - macos-14
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Latest Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+
+      # - name: Cache Cargo registry + index
+      #   uses: actions/cache@v3
+      #   if: ${{ env.CACHE != 'false' }}
+      #   with:
+      #     path: |
+      #       ~/.cargo/bin/
+      #       ~/.cargo/registry/index/
+      #       ~/.cargo/registry/cache/
+      #       ~/.cargo/git/db/
+      #       ./target/
+      #     key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Set Version
+        id: set-version
+        shell: sh
+        run: |
+          VERSION=$(printf "%s" "${{ github.ref_name }}" | sed -e "s|/|-|g")
+          if [ "${{ github.ref_type }}" = "branch" ]; then
+            VERSION=$(printf "%s" "${GITHUB_SHA}" | cut -c-6)
+          fi
+          echo "version: ${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build
+        id: build
+        shell: bash
+        run: |
+          # build avm and anchor separately for now because
+          # of the name conflict in avm/anchor and cli/anchor
+          # cargo build --release -p anchor-cli --bin anchor
+          # cargo build --release -p avm --bin avm
+          cargo build --release --bin hello
+          cp "target/release/hello.exe" "target/release/avm.exe"
+          cp "target/release/hello.exe" "target/release/anchor.exe"
+
+          binary_extension=""
+
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            release_folder="ubuntu-latest"
+          fi
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            binary_extension=".exe"
+            release_folder="windows-latest"
+          fi
+          if [[ "${RUNNER_OS}" == "macOS" ]]; then
+            if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+              release_folder="macos-m1-latest"
+            else
+              release_folder="macos-intel-latest"
+            fi
+          fi
+
+          mkdir -p "${release_folder}"
+          echo "::set-output name=release-folder::${release_folder}"
+          
+          mv "target/release/anchor${binary_extension}" "${release_folder}"
+          mv "target/release/avm${binary_extension}" "${release_folder}"
+          # strip "${release_folder}/*"
+
+      - name: Publish Artifacts
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: actions/upload-artifact@v2
+        with:
+          name: "anchor-${{ steps.build.outputs.release-folder }}-${{ steps.build.set-version.version }}"
+          path: "${{ steps.build.outputs.release-folder }}/*"
+
+      - name: Release Tags
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ steps.build.outputs.release-folder }}/avm*
+            ${{ steps.build.outputs.release-folder }}/anchor*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,13 +61,10 @@ jobs:
           # of the name conflict in avm/anchor and cli/anchor
           cargo build --release -p anchor-cli --bin anchor
           cargo build --release -p avm --bin avm
-          # cargo build --release --bin hello
-          # cp "target/release/hello.exe" "target/release/avm.exe"
-          # cp "target/release/hello.exe" "target/release/anchor.exe"
 
           binary_extension=""
 
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
             release_folder="ubuntu-latest"
           fi
           if [[ "${RUNNER_OS}" == "Windows" ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,13 +64,13 @@ jobs:
 
           binary_extension=""
 
-          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+          if [ "${RUNNER_OS}" = "Linux" ]; then
             release_folder="ubuntu-latest"
-          elif [[ "${RUNNER_OS}" == "Windows" ]]; then
+          elif [ "${RUNNER_OS}" = "Windows" ]; then
             binary_extension=".exe"
             release_folder="windows-latest"
-          elif [[ "${RUNNER_OS}" == "macOS" ]]; then
-            if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+          elif [ "${RUNNER_OS}" = "macOS" ]; then
+            if [ "${{ matrix.os }}" = "macos-14" ]; then
               release_folder="macos-m1-latest"
             else
               release_folder="macos-intel-latest"
@@ -81,11 +81,11 @@ jobs:
           fi
 
           mkdir -p "${release_folder}"
-          echo "release-folder=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "release-folder=${release_folder}" >> "${GITHUB_OUTPUT}"
 
           mv "target/release/anchor${binary_extension}" "${release_folder}"
           mv "target/release/avm${binary_extension}" "${release_folder}"
-          strip "${release_folder}/*"
+          strip "${release_folder}"/*
 
       - name: Publish Artifacts
         if: "!startsWith(github.ref, 'refs/tags/')"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,17 +30,17 @@ jobs:
           default: true
           override: true
 
-      # - name: Cache Cargo registry + index
-      #   uses: actions/cache@v3
-      #   if: ${{ env.CACHE != 'false' }}
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       ./target/
-      #     key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache Cargo registry + index
+        uses: actions/cache@v3
+        if: ${{ env.CACHE != 'false' }}
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Set Version
         id: set-version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [master, "feature/windows-support"]
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,24 +23,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Latest Rust
-        uses: actions-rs/toolchain@v1
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          default: true
           override: true
-
-      - name: Cache Cargo registry + index
-        uses: actions/cache@v3
-        if: ${{ env.CACHE != 'false' }}
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./target/
-          key: cargo-${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Set Version
         id: set-version

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -407,6 +407,19 @@ impl std::fmt::Display for PackageManager {
     }
 }
 
+impl PackageManager {
+    /// On Windows, node executables use the `.cmd` suffix.
+    /// If not added, `process::Command::new()` will fail to find them.
+    /// `cmd /c <command>` is a workaround but it spawns an extra process.
+    /// This method returns the correct executable name for the current platform.
+    pub fn executable_name(&self) -> String {
+        #[cfg(windows)]
+        return format!("{self}.cmd");
+        #[cfg(not(windows))]
+        return self.to_string();
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FeaturesConfig {
     /// Enable account resolution.

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1941,8 +1941,8 @@ fn _build_rust_cwd(
     if std::env::var("HOME").is_err() {
         build_command.env(
             "HOME",
-            std::env::var("USERPROFILE").map_err(|e| {
-                anyhow!("env variable 'HOME' not set and could not read 'USERPROFILE': {e}")
+            std::env::var_os("USERPROFILE").ok_or_else(|| {
+                anyhow!("env variable 'HOME' not set and could not read 'USERPROFILE'")
             })?,
         );
     }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1524,6 +1524,7 @@ fn build_rust_cwd(
     no_docs: bool,
     arch: &ProgramArch,
 ) -> Result<()> {
+    #[allow(unused_mut)]
     let mut cargo_toml_parent = match cargo_toml.parent() {
         Some(parent) => parent.to_owned(),
         None => return Err(anyhow!("Unable to find parent")),

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1533,7 +1533,7 @@ fn build_rust_cwd(
     // build-sbf depends on cargo metadata, which in turn depends on glob
     // to find packages in a workspace
     // but glob breaks on UNC paths like \\?\C:\...\packages\*
-    // so on windows, find the relative path of the package and use
+    // so on windows, use the relative path of the package
     // https://github.com/rust-lang/glob/issues/132
     #[cfg(windows)]
     {
@@ -1932,7 +1932,8 @@ fn _build_rust_cwd(
 ) -> Result<()> {
     let mut build_command = std::process::Command::new("cargo");
 
-    // TODO: fix upstream in solana-build-sbf
+    // TODO: remove once all supported versions include the fix
+    // https://github.com/anza-xyz/agave/pull/3597
     #[cfg(windows)]
     if std::env::var("HOME").is_err() {
         build_command.env(

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1527,7 +1527,7 @@ fn build_rust_cwd(
     no_docs: bool,
     arch: &ProgramArch,
 ) -> Result<()> {
-    #[allow(unused_mut)]
+    #[cfg_attr(not(windows), allow(unused_mut))]
     let mut cargo_toml_parent = match cargo_toml.parent() {
         Some(parent) => parent.to_owned(),
         None => return Err(anyhow!("Unable to find parent")),


### PR DESCRIPTION
# Windows Fixes
- fixes `anchor init`
- fixes `anchor build`
  - fixes #1992
  - fixes #1577
  - should fix #1351
  - fixes #2973
- works around solana-labs/solana#35558
  and #1337
  - fixed in anza-xyz/agave#3597 but workaround needed till unpatched versions are supported
 - the package manager installation command on windows needs to be run with the `.cmd` suffix (like `npm.cmd`)
   this PR adds a `PackageManager::executable_name()` method to return the correct name based on the OS
- if the invocation of the package installation command fails (the specified manager is not installed, or not present on the path) then anchor didn't fallback to `npm` but instead exits with the error `program not found`
   - fixes #1805
 
 ## Release Improvements
Provides prebuilt binaries for `anchor` and `avm`
- for all platforms: Windows, MacOS Intel, MacOS ARM, Linux
- commits to main publish the binaries as artifacts
- tagging a commit creates a GitHub release

**TODO**: The avm install script still needs to be changed to use the prebuilt binaries instead of building from source.