### PR TITLE
[DOC][UI]: Fix issues on light/dark theme

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -20,6 +20,7 @@
         "gh-pages": "^5.0.0",
         "next": "12.2.1",
         "next-plausible": "^3.2.0",
+        "next-themes": "^0.4.3",
         "postcss-focus-visible": "^6.0.4",
         "postcss-import": "^14.1.0",
         "prism-react-renderer": "^1.3.5",
@@ -2934,6 +2935,15 @@
         "next": "^11.1.0 || ^12.0.0 || ^13.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.3.tgz",
+      "integrity": "sha512-nG84VPkTdUHR2YeD89YchvV4I9RbiMAql3GiLEQlPvq1ioaqPaIReK+yMRdg/zgiXws620qS1rU30TiWmmG9lA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -6308,6 +6318,12 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/next-plausible/-/next-plausible-3.7.2.tgz",
       "integrity": "sha512-9PqFiVtD1kZO5gHFYTcgilHhg2WhMzD6I4NK/RUh9DGavD1N11IhNAvyGLFmvB3f4FtHC9IoAsauYDtQBt+riA==",
+      "requires": {}
+    },
+    "next-themes": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.3.tgz",
+      "integrity": "sha512-nG84VPkTdUHR2YeD89YchvV4I9RbiMAql3GiLEQlPvq1ioaqPaIReK+yMRdg/zgiXws620qS1rU30TiWmmG9lA==",
       "requires": {}
     },
     "node-releases": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "gh-pages": "^5.0.0",
     "next": "12.2.1",
     "next-plausible": "^3.2.0",
+    "next-themes": "^0.4.3",
     "postcss-focus-visible": "^6.0.4",
     "postcss-import": "^14.1.0",
     "prism-react-renderer": "^1.3.5",

--- a/docs/src/components/Fence.jsx
+++ b/docs/src/components/Fence.jsx
@@ -1,13 +1,17 @@
 import { Fragment } from 'react'
 import Highlight, { defaultProps } from 'prism-react-renderer'
+import { useTheme } from 'next-themes'
+import lightTheme from 'prism-react-renderer/themes/github'
+
 
 export function Fence({ children, language }) {
+  const { resolvedTheme } = useTheme()
   return (
     <Highlight
       {...defaultProps}
       code={children.trimEnd()}
       language={language}
-      theme={undefined}
+      theme={resolvedTheme !== 'dark' ? lightTheme: undefined }
     >
       {({ className, style, tokens, getTokenProps }) => (
         <pre className={className} style={style}>

--- a/docs/src/components/ThemeSelector.jsx
+++ b/docs/src/components/ThemeSelector.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useTheme } from 'next-themes'
 import { Listbox } from '@headlessui/react'
 import clsx from 'clsx'
@@ -55,12 +55,21 @@ function SystemIcon(props) {
 
 export function ThemeSelector(props) {
   let { theme, setTheme } = useTheme()
-
+  const [mounted, setMounted] = useState(false)
   useEffect(() => {
     if (theme) {
       document.documentElement.setAttribute('data-theme', theme)
     }
   }, [theme])
+
+   // useEffect only runs on the client, so now we can safely show the UI
+   useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return null
+  }
 
   return (
     <Listbox

--- a/docs/src/components/ThemeSelector.jsx
+++ b/docs/src/components/ThemeSelector.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
+import { useTheme } from 'next-themes'
 import { Listbox } from '@headlessui/react'
 import clsx from 'clsx'
 
@@ -53,31 +54,26 @@ function SystemIcon(props) {
 }
 
 export function ThemeSelector(props) {
-  let [selectedTheme, setSelectedTheme] = useState()
+  let { theme, setTheme } = useTheme()
 
   useEffect(() => {
-    if (selectedTheme) {
-      document.documentElement.setAttribute('data-theme', selectedTheme.value)
-    } else {
-      setSelectedTheme(
-        themes.find(
-          (theme) =>
-            theme.value === document.documentElement.getAttribute('data-theme')
-        )
-      )
+    if (theme) {
+      document.documentElement.setAttribute('data-theme', theme)
     }
-  }, [selectedTheme])
+  }, [theme])
 
   return (
     <Listbox
       as="div"
-      value={selectedTheme}
-      onChange={setSelectedTheme}
+      value={themes.find((t) => t.value === theme) }
+      onChange={(theme) => {
+        setTheme(theme.value)
+      }}
       {...props}
     >
       <Listbox.Label className="sr-only">Theme</Listbox.Label>
       <Listbox.Button className="flex h-6 w-6 items-center justify-center rounded-lg shadow-md shadow-black/5 ring-1 ring-black/5 dark:bg-slate-700 dark:ring-inset dark:ring-white/5">
-        <span className="sr-only">{selectedTheme?.name}</span>
+        <span className="sr-only">{theme}</span>
         <LightIcon className="hidden h-4 w-4 fill-sky-400 [[data-theme=light]_&]:block" />
         <DarkIcon className="hidden h-4 w-4 fill-sky-400 [[data-theme=dark]_&]:block" />
         <LightIcon className="hidden h-4 w-4 fill-slate-400 [:not(.dark)[data-theme=system]_&]:block" />

--- a/docs/src/pages/_app.jsx
+++ b/docs/src/pages/_app.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head'
 import { slugifyWithCounter } from '@sindresorhus/slugify'
 import PlausibleProvider from 'next-plausible'
-
+import { ThemeProvider } from 'next-themes'
 import Prism from 'prism-react-renderer/prism'
 ;(typeof global !== 'undefined' ? global : window).Prism = Prism
 
@@ -155,7 +155,7 @@ export default function App({ Component, pageProps }) {
     : []
 
   return (
-    <>
+    <ThemeProvider attribute="class" defaultTheme="system">
       <PlausibleProvider domain="anchor-lang.com" trackOutboundLinks={true}>
         <Head>
           <title>{pageTitle}</title>
@@ -189,6 +189,6 @@ export default function App({ Component, pageProps }) {
           <Component {...pageProps} />
         </Layout>
       </PlausibleProvider>
-    </>
+    </ThemeProvider>
   )
 }

--- a/docs/src/pages/_document.jsx
+++ b/docs/src/pages/_document.jsx
@@ -1,61 +1,9 @@
 import { Head, Html, Main, NextScript } from 'next/document'
 
-const themeScript = `
-  let mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-
-  function updateTheme(savedTheme) {
-    let theme = 'system'
-    try {
-      if (!savedTheme) {
-        savedTheme = window.localStorage.theme
-      }
-      if (savedTheme === 'dark') {
-        theme = 'dark'
-        document.documentElement.classList.add('dark')
-      } else if (savedTheme === 'light') {
-        theme = 'light'
-        document.documentElement.classList.remove('dark')
-      } else if (mediaQuery.matches) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-    } catch {
-      theme = 'light'
-      document.documentElement.classList.remove('dark')
-    }
-    return theme
-  }
-
-  function updateThemeWithoutTransitions(savedTheme) {
-    updateTheme(savedTheme)
-    document.documentElement.classList.add('[&_*]:!transition-none')
-    window.setTimeout(() => {
-      document.documentElement.classList.remove('[&_*]:!transition-none')
-    }, 0)
-  }
-
-  document.documentElement.setAttribute('data-theme', updateTheme())
-
-  new MutationObserver(([{ oldValue }]) => {
-    let newValue = document.documentElement.getAttribute('data-theme')
-    if (newValue !== oldValue) {
-      try {
-        window.localStorage.setItem('theme', newValue)
-      } catch {}
-      updateThemeWithoutTransitions(newValue)
-    }
-  }).observe(document.documentElement, { attributeFilter: ['data-theme'], attributeOldValue: true })
-
-  mediaQuery.addEventListener('change', updateThemeWithoutTransitions)
-  window.addEventListener('storage', updateThemeWithoutTransitions)
-`
-
 export default function Document() {
   return (
     <Html className="antialiased [font-feature-settings:'ss01']" lang="en">
       <Head>
-        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </Head>
       <body className="bg-white dark:bg-slate-900">
         <Main />


### PR DESCRIPTION
This PR fixes: https://github.com/coral-xyz/anchor/issues/3379
I used `"next-themes": "^0.4.3"`, https://ui.shadcn.com/docs/dark-mode/next to handle the shifting of light/dark themes.

with `next-themes`, it can reduce much boilplate code to handle the changing of light/dark mode, and most importantly, it can easily get current theme, which will be used to control the theme of the code block `prism-react-renderer`

in which it uses `import lightTheme from 'prism-react-renderer/themes/github'` for the code block, when in light mode.
as an example:
![image](https://github.com/user-attachments/assets/f5a0f081-7016-4432-b871-3b59353f96ba)

