### PR TITLE
lang: Require `IdlCreateAccounts` instruction authority to be the program authority

### DIFF
--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -1,9 +1,8 @@
 use crate::Program;
-use heck::CamelCase;
 use quote::quote;
 
 pub fn generate(program: &Program) -> proc_macro2::TokenStream {
-    let name: proc_macro2::TokenStream = program.name.to_string().to_camel_case().parse().unwrap();
+    let name = program.struct_name();
     quote! {
         #[cfg(not(feature = "no-entrypoint"))]
         anchor_lang::solana_program::entrypoint!(entry);

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -10,7 +10,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
     let program_name = &program.name;
     // A constant token stream that stores the accounts and functions, required to live
     // inside the target program in order to get the program ID.
-    let idl_accounts_and_functions = idl_accounts_and_functions();
+    let idl_accounts_and_functions = idl_accounts_and_functions(&program.struct_name());
     let non_inlined_idl: proc_macro2::TokenStream = {
         quote! {
             // Entry for all IDL related instructions. Use the "no-idl" feature

--- a/lang/syn/src/codegen/program/idl.rs
+++ b/lang/syn/src/codegen/program/idl.rs
@@ -1,6 +1,8 @@
 use quote::quote;
 
-pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
+pub fn idl_accounts_and_functions(
+    program_struct_ident: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
     quote! {
         use anchor_lang::idl::ERASED_AUTHORITY;
 
@@ -50,8 +52,10 @@ pub fn idl_accounts_and_functions() -> proc_macro2::TokenStream {
             // The system program.
             pub system_program: Program<'info, System>,
             // The program whose state is being constructed.
-            #[account(executable)]
-            pub program: AccountInfo<'info>,
+            #[account(constraint = program.programdata_address()? == Some(program_data.key()))]
+            pub program: Program<'info, program::#program_struct_ident>,
+            #[account(constraint = program_data.upgrade_authority_address == Some(from.key()))]
+            pub program_data: Account<'info, ProgramData>,
         }
 
         // Accounts for Idl instructions.

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod hash;
 
 use codegen::accounts as accounts_codegen;
 use codegen::program as program_codegen;
+use heck::CamelCase;
 use parser::accounts as accounts_parser;
 use parser::program as program_parser;
 use proc_macro2::{Span, TokenStream};
@@ -39,6 +40,13 @@ pub struct Program {
     pub docs: Option<Vec<String>>,
     pub program_mod: ItemMod,
     pub fallback_fn: Option<FallbackFn>,
+}
+
+impl Program {
+    /// Get program struct name (in PascalCase).
+    pub fn struct_name(&self) -> proc_macro2::TokenStream {
+        self.name.to_string().to_camel_case().parse().unwrap()
+    }
 }
 
 impl Parse for Program {


### PR DESCRIPTION
### Problem

As mentioned in https://github.com/coral-xyz/anchor/issues/444#issuecomment-957056279, [`IdlCreateAccounts`](https://github.com/coral-xyz/anchor/blob/be3ab9902fe6657c470317caf63faf2a566d690b/lang/syn/src/codegen/program/idl.rs#L36-L55) instruction is permissionless, meaning anyone can claim the IDL authority of a program if it hasn't yet been claimed:

https://github.com/coral-xyz/anchor/blob/be3ab9902fe6657c470317caf63faf2a566d690b/lang/syn/src/codegen/program/idl.rs#L39-L41

### Summary of changes

Require `from` account of `IdlCreateAccounts` to be the program authority.

**Note:** This only changes the initial IDL creation instruction authorit, meaning any existing IDL authority won't be affected by this change. Ideally the IDL authority and the program deploy authority should be the same, but given that could break existing programs, it makes more sense to only let the IDL account to be initialized by the program deploy authority.

Resolves https://github.com/coral-xyz/anchor/issues/444
