### PR TITLE
Typo fix Update 0.30.0.md

### DIFF
--- a/docs/src/pages/release-notes/0.30.0.md
+++ b/docs/src/pages/release-notes/0.30.0.md
@@ -95,7 +95,7 @@ There are new account constraints for [Token Extensions (Token 2022)](https://so
   - `authority`
   - `program_id`
 
-**Note:** Above values are concatinated with `::` (similar to other Anchor constraints) and have `extensions` prefix e.g. `extensions::group_pointer::authority = <EXPR>`.
+**Note:** Above values are concatenated with `::` (similar to other Anchor constraints) and have `extensions` prefix e.g. `extensions::group_pointer::authority = <EXPR>`.
 
 These constraints can be used both with or without the `init` constraint.
 


### PR DESCRIPTION
# Typo Fix in `0.30.0.md`

**Author**: @BorisNaum  
**Branch**: `BorisNaum:fix-typo`  
**Base**: `coral-xyz:master`  

## Description
This pull request fixes a typo in the `0.30.0.md` file. Specifically, the word "concatinated" has been corrected to "concatenated" to ensure clarity and professionalism.

## Changes
- Corrected the typo: replaced "concatinated" with "concatenated."

