### PR TITLE
chore: fixed incorrect syntax in generic type usage

### DIFF
--- a/lang/attribute/program/src/declare_program/mods/cpi.rs
+++ b/lang/attribute/program/src/declare_program/mods/cpi.rs
@@ -53,7 +53,7 @@ fn gen_cpi_instructions(idl: &Idl) -> proc_macro2::TokenStream {
             Some(ty) => {
                 let ty = convert_idl_type_to_syn_type(ty);
                 (
-                    quote! { anchor_lang::Result<Return::<#ty>> },
+                    quote! { anchor_lang::Result<Return<#ty>> },
                     quote! { Ok(Return::<#ty> { phantom: std::marker::PhantomData }) },
                 )
             },


### PR DESCRIPTION
I’ve removed the unnecessary `::<` symbol from the generic type expression. In Rust, when specifying types for generics, we should avoid these extra characters. The corrected expression now looks like this:

```rust
quote! { anchor_lang::Result<Return<#ty>> }
``` 

This resolves the issue with the syntax and makes the code compile correctly.