### PR TITLE
docs: context added on deployment costs

### DIFF
--- a/docs/content/docs/quickstart/local.mdx
+++ b/docs/content/docs/quickstart/local.mdx
@@ -265,7 +265,7 @@ To deploy your program to devnet, change the `cluster` value to `Devnet`.
 
 Note that deploying to devnet requires your wallet to have enough SOL to cover
 deployment cost. You can get devnet SOL using the
-[Web Faucet](https://faucet.solana.com/).
+[Web Faucet](https://faucet.solana.com/). This deployment cost consists of rent which is refundable upon program closure. 
 
 </Callout>
 


### PR DESCRIPTION
Explained that the deployment costs covers rent which is refundable upon account closure