### PR TITLE
Manually limit `bytemuck_derive` to `">=1.8.1, <1.9.0"` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The minor version will be incremented upon a breaking change and the patch versi
 
 ### Fixes
 
+- cli: Manually limit `bytemuck_derive` to `">=1.8.1, <1.9.0"` ([#3609](https://github.com/coral-xyz/anchor/pull/3609)).
+
 ### Breaking
 
 ## [0.31.0] - 2025-03-08

--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -208,6 +208,9 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = "{3}"
+# Enforce bytemuck_derive version manually due to cargo 1.79 resolution bug.
+# More info here: https://github.com/Lokathor/bytemuck/issues/306
+bytemuck_derive = ">=1.8.1, <1.9.0"
 {4}
 "#,
         name,


### PR DESCRIPTION
`bytemuck_derive` released a new minor version which requires the rust tooling to use 1.84, which uses the 2024 edition. `cargo-sbf` is still on 1.79, so it cannot use this. Normally, cargo should only select  packages that match it's rust version, but in this case it clearly does not, resulting in any new anchor project being broken. More info in https://github.com/coral-xyz/anchor/issues/3606. 

Ideally we'd want to resolve this upstream, for which @Tritlo took the initiative with his PR [here](https://github.com/Lokathor/bytemuck/pull/307), however judging by the [maintainer's comments](https://github.com/Lokathor/bytemuck/issues/306#issuecomment-2737202731) in the issue thread, this one is unlikely to be merged. 

Opening this PR pre-emptively, but I propose waiting on the upstream PR to be finished (either via merge or close) to then decide on closing or merging this PR.