### PR TITLE
bugfix: custom error code parser in ProgramError

### DIFF
--- a/ts/packages/anchor/src/error.ts
+++ b/ts/packages/anchor/src/error.ts
@@ -218,10 +218,10 @@ export class ProgramError extends Error {
     let unparsedErrorCode: string;
     if (errString.includes("custom program error:")) {
       let components = errString.split("custom program error: ");
-      if (components.length !== 2) {
-        return null;
-      } else {
+      if (components.length > 2) {
         unparsedErrorCode = components[1];
+      } else {
+        return null;
       }
     } else {
       const matches = errString.match(/"Custom":([0-9]+)}/g);


### PR DESCRIPTION
The error code below will not be parsed because there are two "custom program error:"s in the error.

```
Error: Simulation failed. 
Message: Transaction simulation failed: Error processing Instruction 2: custom program error: 0x1771. 
Logs: 
[
  "Program rev31KMq4qzt1y1iw926p694MHVVWT57caQrsHLFA4x invoke [1]",
  "Program log: Instruction: ClaimMiner",
  "Program data: +12UGC+xiy4Tzbc04ARQ52SqTDPkFbiiSPdTmhY9gKGDcESjPUUr+DN0qXcfFQAATqcADHAhGQAAAAAAAAAAACbimwQAAAAAAAAAAAAAAABLoOVnAAAAAA==",
  "Program data: vWUq6Q3/38vx7gy1EA2D//7/yOn4PjyXar0f5/ze4Wbkwge3aJWdB+w9IZcgAAAAggIagAcAAAAAAAAAAAAAAGm5Sg8AAAAAxLljxWEAAAAAAAAAAAAAAOf4GwAAAAAAAAAAAAAAAAA=",
  "Program data: ZAOvscU2Tx4HGb3wxOZOxu7WWaHc0D3k6X8oIwPRgRPj5oKIu8dMsGcJfgcAAAAAbjwAAAAAAAAAAAAAAAAAALJHAwAAAAAA",
  "Program log: AnchorError thrown in programs/rewarder/src/processor/miner_update.rs:124. Error Code: NoClaimableRewards. Error Number: 6001. Error Message: No rewards are currently available for claiming.",
  "Program log: Left: 0",
  "Program log: Right: 0",
  "Program rev31KMq4qzt1y1iw926p694MHVVWT57caQrsHLFA4x consumed 17925 of 18836 compute units",
  "Program rev31KMq4qzt1y1iw926p694MHVVWT57caQrsHLFA4x failed: custom program error: 0x1771"
]. 
Catch the SendTransactionError and call getLogs() on it for full details.
```