### PR TITLE
remove broken Serum DEX source link

### DIFF
--- a/tests/lockup/docs/lockups.md
+++ b/tests/lockup/docs/lockups.md
@@ -91,7 +91,7 @@ if any at all.
 
 To create a whitelisted program that receives withdrawals/deposits from/to the Lockup program,
 one needs to implement the whitelist transfer interface, which assumes nothing about the
-`instruction_data` but requires accounts to be provided in a specific [order](https://github.com/project-serum/serum-dex/blob/master/registry/program/src/deposit.rs#L18).
+`instruction_data` but requires accounts to be provided in a specific [order]().
 
 Take staking locked tokens as a working example.
 


### PR DESCRIPTION
Replaced a broken link to serum-dex/registry/program/src/deposit.rs which no longer exists.
Please feel free to suggest a correct or updated path if available — I’ll be happy to adjust the reference accordingly.