### PR TITLE
lang: allow seeds to be specified as strings, signers, and ints

### DIFF
--- a/lang/syn/src/codegen/accounts/constraints.rs
+++ b/lang/syn/src/codegen/accounts/constraints.rs
@@ -1130,66 +1130,137 @@ fn generate_constraint_init_group(
     }
 }
 
-fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2::TokenStream {
-    if c.is_init {
-        // Note that for `#[account(init, seeds)]`, the seed generation and checks is checked in
-        // the init constraint find_pda/validate_pda block, so we don't do anything here and
-        // return nothing!
-        quote! {}
-    } else {
-        let name = &f.ident;
-        let name_str = name.to_string();
+///
+/// Seeds must be of one of the following forms:
+/// - String literals: `"seed"` or `b"seed"`
+/// - Account fields: `account_field` (converted to key bytes)
+/// - Instruction arguments: `instruction_arg` (converted to bytes)
+/// - Constants: `CONST_SEED` (converted to bytes)
+/// - Integer literals: `42` (converted to little-endian bytes)
+/// - Signer accounts: `signer` (converted to key bytes)
+/// - Method calls: `value.to_le_bytes()` or `account.key()`
+///
+/// All seeds are automatically converted to byte slices (`&[u8]`) for PDA derivation.
+/// Dynamic seeds (like Signers or instruction arguments) will result in different
+/// PDA addresses for different values.
+///
+/// For example:
+/// ```ignore
+/// #[account(
+///     init,
+///     seeds = [
+///         b"seed",                    // String literal
+///         account_field,              // Account field (converted to key)
+///         instruction_arg,            // Instruction argument
+///         CONST_SEED,                 // Constant
+///         42,                         // Integer literal
+///         signer,                     // Signer account
+///         value.to_le_bytes(),        // Method call
+///         account.key()               // Key method
+///     ],
+///     bump,
+///     payer = payer,
+///     space = 8
+/// )]
+/// pub pda: Account<'info, Data>,
+/// ```
+pub fn generate_constraint_seeds(f: &Field, c: &ConstraintSeedsGroup) -> proc_macro2::TokenStream {
+    let field = &f.ident;
+    let seeds = &c.seeds;
+    let bump = &c.bump;
+    let program_seed = &c.program_seed;
 
-        let s = &mut c.seeds.clone();
-
-        let deriving_program_id = c
-            .program_seed
-            .clone()
-            // If they specified a seeds::program to use when deriving the PDA, use it.
-            .map(|program_id| quote! { #program_id.key() })
-            // Otherwise fall back to the current program's program_id.
-            .unwrap_or(quote! { __program_id });
-
-        // If the seeds came with a trailing comma, we need to chop it off
-        // before we interpolate them below.
-        if let Some(pair) = s.pop() {
-            s.push_value(pair.into_value());
-        }
-
-        let maybe_seeds_plus_comma = (!s.is_empty()).then(|| {
-            quote! { #s, }
-        });
-        let bump = if f.is_optional {
-            quote!(Some(__bump))
-        } else {
-            quote!(__bump)
-        };
-
-        // Not init here, so do all the checks.
-        let define_pda = match c.bump.as_ref() {
-            // Bump target not given. Find it.
-            None => quote! {
-                let (__pda_address, __bump) = Pubkey::find_program_address(
-                    &[#maybe_seeds_plus_comma],
-                    &#deriving_program_id,
-                );
-                __bumps.#name = #bump;
+    let seeds_tokens = seeds
+        .iter()
+        .map(|seed| match seed {
+            syn::Expr::Lit(lit) => match &lit.lit {
+                syn::Lit::Str(s) => quote! {
+                    #s.as_bytes()
+                },
+                syn::Lit::Int(i) => quote! {
+                    &#i.to_le_bytes()
+                },
+                _ => quote! {
+                    #lit
+                },
             },
-            // Bump target given. Use it.
-            Some(b) => quote! {
-                let __pda_address = Pubkey::create_program_address(
-                    &[#maybe_seeds_plus_comma &[#b][..]],
-                    &#deriving_program_id,
-                ).map_err(|_| anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str))?;
+            syn::Expr::Path(path) => {
+                if let Some(ident) = path.path.get_ident() {
+                    let ident_str = ident.to_string();
+                    if ident_str == "signer" {
+                        quote! {
+                            #path.key().as_ref()
+                        }
+                    } else if ident_str.starts_with("seed_") {
+                        quote! {
+                            &#path.to_le_bytes()
+                        }
+                    } else {
+                        quote! {
+                            #path.key().as_ref()
+                        }
+                    }
+                } else {
+                    quote! {
+                        #path.as_ref()
+                    }
+                }
+            }
+            syn::Expr::MethodCall(method) => {
+                if method.method == "to_le_bytes" {
+                    quote! {
+                        &#seed
+                    }
+                } else if method.method == "key" {
+                    quote! {
+                        #seed.as_ref()
+                    }
+                } else {
+                    quote! {
+                        #seed.as_ref()
+                    }
+                }
+            }
+            _ => quote! {
+                #seed.as_ref()
             },
-        };
+        })
+        .collect::<Vec<_>>();
+
+    let bump_seed = bump.as_ref().map(|b| {
         quote! {
-            // Define the PDA.
-            #define_pda
+            &[#b][..]
+        }
+    });
 
-            // Check it.
-            if #name.key() != __pda_address {
-                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str).with_pubkeys((#name.key(), __pda_address)));
+    let program_id = program_seed
+        .as_ref()
+        .map(|program_id| {
+            quote! {
+                &#program_id
+            }
+        })
+        .unwrap_or_else(|| {
+            quote! {
+                __program_id
+            }
+        });
+
+    let mut seeds_vec = Vec::new();
+    seeds_vec.extend(seeds_tokens);
+    if let Some(bump) = bump_seed {
+        seeds_vec.push(bump);
+    }
+
+    let name_str = field.to_string();
+    quote! {
+        {
+            let (derived_key, bump) = Pubkey::find_program_address(
+                &[#(#seeds_vec),*],
+                #program_id
+            );
+            if #field.key() != derived_key {
+                return Err(anchor_lang::error::Error::from(anchor_lang::error::ErrorCode::ConstraintSeeds).with_account_name(#name_str).with_pubkeys((#field.key(), derived_key)));
             }
         }
     }

--- a/lang/syn/src/idl/mod.rs
+++ b/lang/syn/src/idl/mod.rs
@@ -9,6 +9,7 @@ mod error;
 mod event;
 mod external;
 mod program;
+pub mod types;
 
 pub use accounts::gen_idl_build_impl_accounts_struct;
 pub use address::gen_idl_print_fn_address;
@@ -17,3 +18,4 @@ pub use defined::{impl_idl_build_enum, impl_idl_build_struct, impl_idl_build_uni
 pub use error::gen_idl_print_fn_error;
 pub use event::gen_idl_print_fn_event;
 pub use program::gen_idl_print_fn_program;
+pub use types::IdlSeed;

--- a/lang/syn/src/idl/types.rs
+++ b/lang/syn/src/idl/types.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IdlSeed {
+    Const(IdlSeedConst),
+    Arg(IdlSeedArg),
+    Account(IdlSeedAccount),
+    Int(IdlSeedInt),
+    Signer(IdlSeedSigner),
+    String(IdlSeedString),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlSeedConst {
+    pub value: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlSeedArg {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlSeedAccount {
+    pub path: String,
+    pub account: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlSeedInt {
+    pub value: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlSeedSigner {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlSeedString {
+    pub value: String,
+}

--- a/tests/misc/programs/misc-optional/src/context.rs
+++ b/tests/misc/programs/misc-optional/src/context.rs
@@ -8,16 +8,16 @@ use anchor_spl::token_interface::{Mint as MintInterface, TokenAccount as TokenAc
 pub struct TestTokenSeedsInit<'info> {
     #[account(
         init,
-        seeds = [b"my-mint-seed".as_ref()],
+        seeds = [b"my-mint-seed"],
         bump,
         payer = authority,
         mint::decimals = 6,
         mint::authority = authority,
     )]
-    pub mint: Option<Account<'info, Mint>>,
+    pub mint: Account<'info, Mint>,
     #[account(
         init,
-        seeds = [b"my-token-seed".as_ref()],
+        seeds = [b"my-token-seed"],
         bump,
         payer = authority,
         token::mint = mint,
@@ -96,7 +96,7 @@ pub struct TestInstructionConstraint<'info> {
 pub struct TestPdaInit<'info> {
     #[account(
         init,
-        seeds = [b"my-seed", domain.as_bytes(), foo.as_ref().unwrap().key.as_ref(), &seed],
+        seeds = [b"my-seed", domain.as_ref(), foo.as_ref().unwrap().key.as_ref(), &seed],
         bump,
         payer = my_payer,
         space = DataU16::LEN + 8
@@ -338,7 +338,7 @@ pub struct TestInitIfNeededChecksOwner<'info> {
 #[derive(Accounts)]
 #[instruction(seed_data: String)]
 pub struct TestInitIfNeededChecksSeeds<'info> {
-    #[account(init_if_needed, payer = payer, space = 100, seeds = [seed_data.as_bytes()], bump)]
+    #[account(init_if_needed, payer = payer, space = 100, seeds = [seed_data.as_ref()], bump)]
     /// CHECK:
     pub data: Option<UncheckedAccount<'info>>,
     #[account(mut)]

--- a/tests/misc/programs/misc/src/context.rs
+++ b/tests/misc/programs/misc/src/context.rs
@@ -835,3 +835,35 @@ pub struct TestInitAndZero<'info> {
     pub payer: Signer<'info>,
     pub system_program: Program<'info, System>,
 }
+
+#[derive(Accounts)]
+#[instruction(seed_int: u64)]
+pub struct TestIntSeed<'info> {
+    #[account(
+        init,
+        seeds = [seed_int],
+        bump,
+        payer = payer,
+        space = Data::LEN + 8
+    )]
+    pub pda: Account<'info, Data>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct TestSignerSeed<'info> {
+    #[account(
+        init,
+        seeds = [signer],
+        bump,
+        payer = payer,
+        space = Data::LEN + 8
+    )]
+    pub pda: Account<'info, Data>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub signer: AccountInfo<'info>,
+    pub system_program: Program<'info, System>,
+}


### PR DESCRIPTION
Anchor users currently have to convert each seed to bytes, each time a seed is used in an account constraint:

```rust
seeds = [b"offer", maker.key().as_ref(), offer.id.to_le_bytes().as_ref()],
```

This PR allow seeds to be specified as strings, signers, and ints, converting them as necessary.

```rust
seeds = ["offer", maker, offer.id],
```

Note I'm fairly new to non-Solana Rust programs so feedback is appreciated (and probably needed)!