### PR TITLE
fix: dead_code warning in zerocopy test

### DIFF
--- a/lang/tests/space.rs
+++ b/lang/tests/space.rs
@@ -1,4 +1,3 @@
-
 #![allow(dead_code)]
 
 use anchor_lang::prelude::*;


### PR DESCRIPTION
Regression in between Rust versions caused a dead_code warning on clippy. Ignored