### PR TITLE
docs: fix broken link to UpgradeableLoaderState in Solana loader v3 docs

### DIFF
--- a/lang/src/accounts/program.rs
+++ b/lang/src/accounts/program.rs
@@ -18,7 +18,6 @@ use std::ops::Deref;
 /// The type has a `programdata_address` function that will return `Option::Some`
 /// if the program is owned by the [`BPFUpgradeableLoader`](https://docs.rs/solana-program/latest/solana_program/bpf_loader_upgradeable/index.html)
 /// which will contain the `programdata_address` property of the `Program` variant of the [`UpgradeableLoaderState`](https://docs.rs/solana-loader-v3-interface/6.1.0/solana_loader_v3_interface/state/enum.UpgradeableLoaderState.html) enum.
-
 ///
 /// # Table of Contents
 /// - [Basic Functionality](#basic-functionality)


### PR DESCRIPTION
- Updated outdated `solana_program` reference to point to `solana-loader-v3-interface` documentation.  

https://docs.rs/solana-program/latest/solana_program/bpf_loader_upgradeable/enum.UpgradeableLoaderState.html - 404
https://docs.rs/solana-loader-v3-interface/latest/solana_loader_v3_interface/state/enum.UpgradeableLoaderState.html - the correct link