### PR TITLE
[#2993] keep original directory

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2114,7 +2114,7 @@ fn idl_init(
                 let full_path = original_dir.join(&idl_filepath);
                 fs::read(full_path)?
             }
-        } ;
+        };
         let idl = convert_idl(&idl)?;
 
         let idl_address = create_idl_account(cfg, &keypair, &program_id, &idl, priority_fee)?;


### PR DESCRIPTION
**Root Cause of Issue #2993**

When the command is executed, the code first calls with_workspace, which switches the current working directory.
	•	with_workspace ensures that the current directory is always the top-level workspace directory.
	•	As a result, when the command tries to read a file, it looks in the top-level directory rather than the directory from which the command was originally invoked.

⸻

**Possible Solutions**
	1.	**Modify with_workspace to not change the current directory**
	•	Pros: The file would be read relative to the original directory.
	•	Cons: Not backward-compatible and could introduce other issues.
	2.	**Update the documentation**
	•	Require that file paths be given relative to the top-level workspace directory, not the current directory.
	•	Cons: Tab completion for filenames would no longer work in the original directory.
	3.	**Pass the original directory into the closure**
	•	The closure can first try reading the file in the top-level workspace (for backward compatibility) and, if not found, fallback to the original directory from which the command was invoked.
