### PR TITLE
fix: use absolute path for Pubkey inside macro

### DIFF
--- a/lang/syn/src/codegen/accounts/__client_accounts.rs
+++ b/lang/syn/src/codegen/accounts/__client_accounts.rs
@@ -85,12 +85,12 @@ pub fn generate(
                 if f.is_optional {
                     quote! {
                         #docs
-                        pub #name: Option<Pubkey>
+                        pub #name: Option<anchor_lang::solana_program::pubkey::Pubkey>
                     }
                 } else {
                     quote! {
                         #docs
-                        pub #name: Pubkey
+                        pub #name: anchor_lang::solana_program::pubkey::Pubkey
                     }
                 }
             }


### PR DESCRIPTION
In the `__client_accounts_*` module generated by `#[derive(Accounts)]`, `Pubkey` isn't referred with a full path.
This isn't a big issue because most of the time the developer has `use anchor_lang::prelude::*;` in the same file.

There are however some edgecases where this will cause compilation failures. For example in documentation tests that use `#[derive(Accounts)]`, the compiler will not be able to find `Pubkey`.
