### PR TITLE
feat-add: anchor cli keygen

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -44,3 +44,5 @@ syn = { version = "1.0.60", features = ["full", "extra-traits"] }
 tar = "0.4.35"
 toml = "0.7.6"
 walkdir = "2.3.2"
+tiny-bip39 = "2.0"
+ed25519-dalek-bip32 = "0.3"


### PR DESCRIPTION
Implement `anchor keygen` commands (new/pubkey/recover) to reduce Solana CLI dependency (#3866 )

- Adds native keypair generation, public key extraction, and seed phrase recovery functionality to Anchor CLI, eliminating the need to shell out to `solana-keygen`. 
- Commands work both inside and outside workspace directories, providing flexibility for developers.

Dependencies added:
- `tiny-bip39 = "2.0"` 
- `ed25519-dalek-bip32 = "0.3"` 
