### PR TITLE
Fix typos across multipe file

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -436,7 +436,7 @@ pub enum IdlCommand {
         priority_fee: Option<u64>,
     },
     /// Command to remove the ability to modify the IDL account. This should
-    /// likely be used in conjection with eliminating an "upgrade authority" on
+    /// likely be used in conjunction with eliminating an "upgrade authority" on
     /// the program.
     EraseAuthority {
         #[clap(short, long)]

--- a/docs/content/docs/basics/cpi.mdx
+++ b/docs/content/docs/basics/cpi.mdx
@@ -6,7 +6,7 @@ description:
 ---
 
 Cross Program Invocations (CPI) refer to the process of one program invoking
-instructions of another program, which enables the composibility of Solana
+instructions of another program, which enables the composability of Solana
 programs.
 
 This section will cover the basics of implementing CPIs in an Anchor program,

--- a/docs/content/docs/updates/release-notes/0-31-0.mdx
+++ b/docs/content/docs/updates/release-notes/0-31-0.mdx
@@ -102,7 +102,7 @@ Program name: `my-program`
 ### Pass `cargo` args to IDL build
 
 Both `anchor build` and `anchor idl build` commands pass the `cargo` arguments
-to the underyling IDL build command. For example:
+to the underlying IDL build command. For example:
 
 ```
 anchor build -- --features my-feature
@@ -274,7 +274,7 @@ still allows empty discriminators because some non-Anchor programs, e.g. the SPL
 Token program, don't have account discriminators. In that case, safety checks
 should never depend on the discriminator.
 
-Additionally, the IDL generation step also checks whether you have ambigious
+Additionally, the IDL generation step also checks whether you have ambiguous
 discriminators i.e. discriminators that can be used for multiple types. However,
 you should still consider future possibilities, especially when working with
 1-byte discriminators. For example, having an account with discriminator `[1]`
@@ -440,7 +440,7 @@ Building the IDL via the
 [`build_idl`](https://github.com/coral-xyz/anchor/blob/v0.31.0/idl/src/build.rs#L119)
 function made it impossible to extend its functionality e.g. add new parameters
 without a breaking change. To solve this problem, there is a new way to build
-IDLs programatically:
+IDLs programmatically:
 
 ```rs
 let idl = IdlBuilder::new().program_path(path).skip_lint(true).build()?;

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -239,7 +239,7 @@ pub trait AccountsExit<'info>: ToAccountMetas + ToAccountInfos<'info> {
     }
 }
 
-/// The close procedure to initiate garabage collection of an account, allowing
+/// The close procedure to initiate garbage collection of an account, allowing
 /// one to retrieve the rent exemption.
 pub trait AccountsClose<'info>: ToAccountInfos<'info> {
     fn close(&self, sol_destination: AccountInfo<'info>) -> Result<()>;

--- a/tests/lockup/programs/lockup/src/lib.rs
+++ b/tests/lockup/programs/lockup/src/lib.rs
@@ -126,7 +126,7 @@ pub mod lockup {
         let cpi_ctx = CpiContext::from(&*ctx.accounts).with_signer(signer);
         token::transfer(cpi_ctx, amount)?;
 
-        // Bookeeping.
+        // Bookkeeping.
         let vesting = &mut ctx.accounts.vesting;
         vesting.outstanding -= amount;
 

--- a/tests/zero-copy/programs/zero-copy/src/lib.rs
+++ b/tests/zero-copy/programs/zero-copy/src/lib.rs
@@ -170,7 +170,7 @@ pub struct Event {
 //    traits, so any types in method signatures must as well.
 // 2. All types for zero copy deserialization are `#[repr(packed)]`. However,
 //    the implementation of AnchorSerialize (i.e. borsh), uses references
-//    to the fields it serializes. So if we were to just throw tehse derives
+//    to the fields it serializes. So if we were to just throw these derives
 //    onto the other `Event` struct, we would have references to
 //    `#[repr(packed)]` fields, which is unsafe. To avoid the unsafeness, we
 //    just use a separate type.


### PR DESCRIPTION
Fixed a bunch of typos across files — ready to merge if everything looks good.

cli/src/lib.rs: conjection → conjunction
CPI docs: composibility → composability
Release notes/docs: ambigious → ambiguous, programatically → programmatically, and cleaned up “underlying”
lang/src/lib.rs: garabage → garbage
Tests: Bookeeping → Bookkeeping
Zero-copy comments: tehse → these