### PR TITLE
fix(cli): upd8 rust ver n yeet old deps (nuwu~ approved 💖)

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -204,11 +204,13 @@ mollusk-svm = "~0.4"
     };
 
     format!(
-        r#"[package]
+        r#"cargo-features = ["edition2024"]
+
+[package]
 name = "{0}"
 version = "0.1.0"
 description = "Created with Anchor"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "lib"]
@@ -744,12 +746,16 @@ impl TestTemplate {
 }
 
 pub fn tests_cargo_toml(name: &str) -> String {
+    // TODO: remove `cargo-features` flag once figured out who the fuck is relying
+    // on Cargo (1.84.0 (12fe57a9d 2025-04-07)). Prolly solana cli, cz it is sus tho.
     format!(
-        r#"[package]
+        r#"cargo-features = ["edition2024"]
+
+[package]
 name = "tests"
 version = "0.1.0"
 description = "Created with Anchor"
-edition = "2021"
+edition = "2024"
 rust-version = "{msrv}"
 
 [dependencies]


### PR DESCRIPTION
Hewwo interwebz cutiesss~ (⁄⁄•⁄ω⁄•⁄⁄)ﾉ

I'm back, missed the boys n' my laptop bb! Sooooo, quick update from your resident dev-nyan: the CLI was cling8y and using an ooooold Rust too8chain, so I bumped it to **Rust 2024**. All shiny now `nyuwu~`.

Little kawaii tech notes:

* If you run `anchor test`, Rust does the whole thing (npm/yarn not needed). I tested it, fixed it, and it pu88s 🐾.
* One tiny myste8y left: something's still depending on **ca8go 1.84.0**. P8olly the Solana CLI, but we should investig8 who's cling8y with that vershun.

okai bye-bye for now~ stay fluff and codie ♥︎
٩(◕‿◕)۶