### PR TITLE
Fix IDL generation failure with account field references in seeds

### DIFF
--- a/lang/syn/src/idl/accounts.rs
+++ b/lang/syn/src/idl/accounts.rs
@@ -418,7 +418,12 @@ impl SeedPath {
         }
 
         // Break up the seed into each subfield component.
-        let mut components = seed_str.split('.').collect::<Vec<_>>();
+        // Trim whitespace from components to handle formatted token streams (e.g., "user . key ()")
+        let mut components = seed_str
+            .split('.')
+            .map(|s| s.trim())
+            .collect::<Vec<_>>();
+
         if components.len() <= 1 {
             return Err(anyhow!("Seed is in unexpected format: {seed:#?}"));
         }


### PR DESCRIPTION
Fixes #3947

When seeds contain account field or instruction parameter references (e.g., `user.key().as_ref()` or `project_id.as_ref()`), the IDL generation fails with "cannot find value in scope" errors.

Root Cause:
- syn::Expr::to_token_stream() produces formatted output with spaces (e.g., "user . key () . as_ref ()")
- Splitting on '.' preserves whitespace: ["user ", " key () ", ...]
- Variable name becomes "user " (with trailing space)
- Rust cannot find "user " because the variable is named "user"

Solution:
Trim whitespace from each component after splitting to ensure clean variable names for scope resolution.

Tested with contract using:
- Instruction params in seeds: project_id.as_ref()
- Account fields in seeds: user.key().as_ref()

Build now succeeds and generates complete IDL with proper seed info.