### PR TITLE
feat(lang): Add error type support to declare_program! macro

### DIFF
--- a/lang/attribute/program/src/declare_program/mod.rs
+++ b/lang/attribute/program/src/declare_program/mod.rs
@@ -71,6 +71,14 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
     // Utils
     let utils_mod = gen_utils_mod(idl);
 
+    let errors_re_export = if !idl.errors.is_empty() {
+        quote! {
+            pub use errors::ProgramError;
+        }
+    } else {
+        quote! {}
+    };
+
     quote! {
         #docs
         pub mod #name {
@@ -87,6 +95,9 @@ fn gen_program(idl: &Idl, name: &syn::Ident) -> proc_macro2::TokenStream {
             #events_mod
             #types_mod
             #errors_mod
+
+            // Re-export error types to make them easily accessible
+            #errors_re_export
 
             #cpi_mod
             #client_mod

--- a/lang/attribute/program/src/declare_program/mods/utils.rs
+++ b/lang/attribute/program/src/declare_program/mods/utils.rs
@@ -56,7 +56,7 @@ fn gen_account(idl: &Idl) -> proc_macro2::TokenStream {
 
             fn try_from(value: &[u8]) -> Result<Self> {
                 #(#if_statements)*
-                Err(ProgramError::InvalidArgument.into())
+                Err(anchor_lang::prelude::ProgramError::InvalidArgument.into())
             }
         }
     }
@@ -102,7 +102,7 @@ fn gen_event(idl: &Idl) -> proc_macro2::TokenStream {
 
             fn try_from(value: &[u8]) -> Result<Self> {
                 #(#if_statements)*
-                Err(ProgramError::InvalidArgument.into())
+                Err(anchor_lang::prelude::ProgramError::InvalidArgument.into())
             }
         }
     }

--- a/tests/declare-program/programs/declare-program/src/lib.rs
+++ b/tests/declare-program/programs/declare-program/src/lib.rs
@@ -118,6 +118,14 @@ pub mod declare_program {
 
         Ok(())
     }
+
+    pub fn test_amm_v3_errors(_ctx: Context<Utils>) -> Result<()> {
+        let _error: amm_v3::ProgramError = amm_v3::ProgramError::LOK;
+
+        let _error2: amm_v3::errors::ProgramError = amm_v3::errors::ProgramError::NotApproved;
+
+        Ok(())
+    }
 }
 
 #[derive(Accounts)]


### PR DESCRIPTION
  This PR allows external programs declared with declare_program! to expose their error types, making it easier to check and handle errors from external programs. Error types are re-exported at the top level of the declared program module for convenient access.

  Fixes #3902