### PR TITLE
docs: fix TypeScript Program constructor example to use provider

### DIFF
--- a/docs/content/docs/clients/rust.mdx
+++ b/docs/content/docs/clients/rust.mdx
@@ -170,15 +170,18 @@ Below is the `src/main.rs` file for interacting with the program:
 
 ```rust title="src/main.rs"
 use anchor_client::{
-    solana_client::rpc_client::RpcClient,
+    Client,
+    Cluster,
     solana_sdk::{
-        commitment_config::CommitmentConfig, native_token::LAMPORTS_PER_SOL, signature::Keypair,
+        commitment_config::CommitmentConfig,
+        native_token::LAMPORTS_PER_SOL,
+        signature::Keypair,
+        signer::Signer,
         system_program,
     },
-    solana_signer::Signer,
-    Client, Cluster,
 };
 use anchor_lang::prelude::*;
+use solana_rpc_client::rpc_client::RpcClient;
 use std::rc::Rc;
 
 declare_program!(example);

--- a/docs/content/docs/clients/typescript.mdx
+++ b/docs/content/docs/clients/typescript.mdx
@@ -53,10 +53,8 @@ const provider = new AnchorProvider(connection, wallet, {});
 setProvider(provider);
 
 // [!code word:Program]
-// [!code highlight:3]
-export const program = new Program(idl as HelloAnchor, {
-  connection,
-});
+// [!code highlight]
+export const program = new Program(idl as HelloAnchor, provider);
 ```
 
 In the code snippet above:
@@ -66,10 +64,15 @@ In the code snippet above:
 - `idlType.ts` is the IDL type (for use with TypeScript), found at
   `/target/types/<program-name>.ts` in an Anchor project.
 
-Alternatively, you can create an `Program` instance using only the IDL and the
+The `Program` instance is created with both the IDL and the `provider`, which
+enables signing and sending transactions. This allows you to call `.rpc()`
+methods on program instructions.
+
+Alternatively, you can create a `Program` instance using only the IDL and the
 `Connection` to a Solana cluster. This means there is no default `Wallet`, but
 allows you to use the `Program` to fetch accounts or build instructions without
-a connected wallet.
+a connected wallet. Note that this read-only configuration does not support
+signing or sending transactions.
 
 ```ts
 import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";


### PR DESCRIPTION
Fixes #4086

The previous example created a provider but didn't use it when constructing the Program instance, which resulted in a provider-less Program that could not sign or send transactions. Attempting to call .rpc() methods resulted in: 'This function requires Provider.sendAndConfirm to be implemented.'

Changes:
- Updated Program constructor to use provider instead of { connection }
- Added clarification that provider enables signing/sending transactions
- Enhanced the read-only alternative example description to explicitly state it does not support signing or sending transactions