### PR TITLE
docs: fix Rust client import paths to use correct crate paths

### DIFF
--- a/docs/content/docs/clients/rust.mdx
+++ b/docs/content/docs/clients/rust.mdx
@@ -170,15 +170,18 @@ Below is the `src/main.rs` file for interacting with the program:
 
 ```rust title="src/main.rs"
 use anchor_client::{
-    solana_client::rpc_client::RpcClient,
+    Client,
+    Cluster,
     solana_sdk::{
-        commitment_config::CommitmentConfig, native_token::LAMPORTS_PER_SOL, signature::Keypair,
+        commitment_config::CommitmentConfig,
+        native_token::LAMPORTS_PER_SOL,
+        signature::Keypair,
+        signer::Signer,
         system_program,
     },
-    solana_signer::Signer,
-    Client, Cluster,
 };
 use anchor_lang::prelude::*;
+use solana_rpc_client::rpc_client::RpcClient;
 use std::rc::Rc;
 
 declare_program!(example);


### PR DESCRIPTION
Fixes #4093

The previous example used incorrect import paths that don't exist:
- anchor_client::solana_client::rpc_client::RpcClient (anchor_client doesn't re-export solana_client)
- anchor_client::solana_signer::Signer (anchor_client doesn't re-export solana_signer)

Changes:
- Import RpcClient directly from solana_rpc_client crate
- Import Signer from solana_sdk::signer (which is re-exported by anchor_client)
- Reorganized imports for clarity and consistency with anchor_client's own examples