### PR TITLE
refactor(idl): Parse seed path with pattern matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -27,7 +27,7 @@ bs58 = "0.5"
 # `idl-build` feature only
 cargo_toml = { version = "0.19", optional = true }
 heck = "0.3"
-proc-macro2 = { version = "1", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.100", features = ["span-locations"] }
 quote = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Makes IDL parsing more resilient against #4042