### PR TITLE
chore: remove usage of 'any' type in buffer-layout definitions

### DIFF
--- a/ts/packages/anchor/types/buffer-layout/index.d.ts
+++ b/ts/packages/anchor/types/buffer-layout/index.d.ts
@@ -1,6 +1,6 @@
 
 declare module 'buffer-layout' {
-	// TODO: remove `any`.
+  // TODO: remove `any`.
   export class Layout<T = any> {
     span: number;
     property?: string;
@@ -12,10 +12,7 @@ declare module 'buffer-layout' {
     getSpan(b: Buffer, offset?: number): number;
     replicate(name: string): this;
   }
-	// TODO: remove any.
-  export class Structure<T = any> extends Layout<T> {
-		span: any;
-	}
+  export class Structure<T = any> extends Layout<T> { }
   export function greedy(
     elementSpan?: number,
     property?: string,

--- a/ts/packages/borsh/types/buffer-layout/index.d.ts
+++ b/ts/packages/borsh/types/buffer-layout/index.d.ts
@@ -1,6 +1,6 @@
 
 declare module 'buffer-layout' {
-	// TODO: remove `any`.
+  // TODO: remove `any`.
   export class Layout<T = any> {
     span: number;
     property?: string;
@@ -12,10 +12,7 @@ declare module 'buffer-layout' {
     getSpan(b: Buffer, offset?: number): number;
     replicate(name: string): this;
   }
-	// TODO: remove any.
-  export class Structure<T = any> extends Layout<T> {
-		span: any;
-	}
+  export class Structure<T = any> extends Layout<T> { }
   export function greedy(
     elementSpan?: number,
     property?: string,


### PR DESCRIPTION
This PR resolves existing TODO comments in `borsh` and `anchor` packages.
I removed the explicit `any` type for the `span` property in the [Structure](cci:2://file:///home/raushan/anchor/ts/packages/borsh/types/buffer-layout/index.d.ts:14:2-14:55) class.
It now correctly inherits the `number` type from the parent [Layout](cci:2://file:///home/raushan/anchor/ts/packages/borsh/types/buffer-layout/index.d.ts:3:2-13:3) class.

Files changed:
- [ts/packages/borsh/types/buffer-layout/index.d.ts](cci:7://file:///home/raushan/anchor/ts/packages/borsh/types/buffer-layout/index.d.ts:0:0-0:0)
- `ts/packages/anchor/types/buffer-layout/index.d.ts`