### PR TITLE
fix: correct InterfaceAccount try_from_unchecked docs

### DIFF
--- a/lang/src/accounts/interface_account.rs
+++ b/lang/src/accounts/interface_account.rs
@@ -253,9 +253,12 @@ impl<'a, T: AccountSerialize + AccountDeserialize + CheckOwner + Clone> Interfac
 
     /// Deserializes the given `info` into a `InterfaceAccount` **without** checking
     /// the account discriminator. This is intended for foreign program accounts.
-    /// Prefer `Self::try_from` when you also want the ownership check, but note
-    /// that both skip Anchor discriminator checks, and `try_from` additionally
-    /// enforces ownership.
+    ///
+    /// Both this method and [`Self::try_from`] validate program ownership via
+    /// [`T::check_owner`] and skip Anchor discriminator checks. This method is the
+    /// lower-level primitive that performs the actual deserialization, while
+    /// [`Self::try_from`] is the higher-level entry point used by the `Accounts`
+    /// derive.
     #[inline(never)]
     pub fn try_from_unchecked(info: &'a AccountInfo<'a>) -> Result<Self> {
         if info.owner == &system_program::ID && info.lamports() == 0 {


### PR DESCRIPTION
The doc comment for InterfaceAccount::try_from_unchecked claimed that only try_from performs an ownership check and that try_from_unchecked should be used when you do not need it. In reality both methods validate ownership via T::check_owner and skip only the Anchor discriminator, matching the pattern used by Account and LazyAccount. This change updates the documentation to accurately describe the behavior without altering any runtime semantics.