### PR TITLE
feat(ts): Add MethodPubkeys utility type

### DIFF
--- a/tests/declare-program/tests/declare-program.ts
+++ b/tests/declare-program/tests/declare-program.ts
@@ -10,12 +10,7 @@ describe("declare-program", () => {
     anchor.workspace.declareProgram;
   const externalProgram: anchor.Program<External> = anchor.workspace.external;
 
-  // TODO: Add a utility type that does this?
-  let pubkeys: Awaited<
-    ReturnType<
-      ReturnType<typeof externalProgram["methods"]["init"]>["rpcAndKeys"]
-    >
-  >["pubkeys"];
+  let pubkeys: anchor.MethodPubkeys<External, "init">;
 
   before(async () => {
     pubkeys = (await externalProgram.methods.init().rpcAndKeys()).pubkeys;

--- a/ts/packages/anchor/src/program/namespace/index.ts
+++ b/ts/packages/anchor/src/program/namespace/index.ts
@@ -18,7 +18,8 @@ export { TransactionNamespace, TransactionFn } from "./transaction.js";
 export { RpcNamespace, RpcFn } from "./rpc.js";
 export { AccountNamespace, AccountClient, ProgramAccount } from "./account.js";
 export { SimulateNamespace, SimulateFn } from "./simulate.js";
-export { IdlAccounts, IdlTypes, DecodeType, IdlEvents } from "./types.js";
+export { IdlAccounts, IdlTypes, DecodeType, IdlEvents,
+  MethodPubkeys } from "./types.js";
 export { MethodsBuilderFactory, MethodsNamespace } from "./methods";
 export { ViewNamespace, ViewFn } from "./views";
 

--- a/ts/packages/anchor/src/program/namespace/types.ts
+++ b/ts/packages/anchor/src/program/namespace/types.ts
@@ -103,6 +103,14 @@ export type InstructionAccountAddresses<
   I extends AllInstructions<IDL>
 > = InstructionAccountsAddresses<I["accounts"][number]>;
 
+/**
+ * Returns a type of instruction name to the resolved account addresses.
+ */
+export type MethodPubkeys<
+  IDL extends Idl,
+  M extends keyof AllInstructionsMap<IDL>
+> = InstructionAccountAddresses<IDL, AllInstructionsMap<IDL>[M]>;
+
 type InstructionAccountsAddresses<
   A extends IdlInstructionAccountItem = IdlInstructionAccountItem
 > = {


### PR DESCRIPTION
Fixes Issue #4135 

This PR introduces the `MethodPubkeys<IDL, MethodName>` utility type to the TypeScript client.  
The new type allows developers to easily extract resolved account public keys from an instruction’s `rpcAndKeys` call.

It also removes verbose boilerplate in the `declare-program` integration test, resolving a long-standing  #TODO.
 
### Changes

#### 1. Implemented `MethodPubkeys` Utility  
- `ts/packages/anchor/src/program/namespace/types.ts`  

Defined a new generic utility type that maps an instruction name to its resolved account addresses.

#### 2. Exported Utility  
- `ts/packages/anchor/src/program/namespace/index.ts`  

Re-exported the type to ensure it is available via the main `@coral-xyz/anchor` import.

#### 3. Refactored Integration Tests  
- `tests/declare-program/tests/declare-program.ts`  

Replaced the verbose `Awaited<ReturnType<...>>` boilerplate with the new utility type.

### Test

- Ran `yarn jest` on a custom verification suite to ensure correct type resolution across complex IDLs.
- Confirmed that `declare-program.ts` compiles and passes with the new type.

