### PR TITLE
fix: change `.key()` -> `to_account_info()` for CPI in mint token's doc

### DIFF
--- a/docs/content/docs/tokens/basics/mint-tokens.mdx
+++ b/docs/content/docs/tokens/basics/mint-tokens.mdx
@@ -71,7 +71,7 @@ pub mod token_example {
             to: ctx.accounts.token_account.to_account_info(),
             authority: ctx.accounts.signer.to_account_info(),
         };
-        let cpi_program_id = ctx.accounts.token_program.key();
+        let cpi_program_id = ctx.accounts.token_program.to_account_info();
         let cpi_context = CpiContext::new(cpi_program_id, cpi_accounts);
         token_interface::mint_to(cpi_context, amount)?;
         Ok(())
@@ -172,7 +172,7 @@ pub mod token_example {
             to: ctx.accounts.token_account.to_account_info(),
             authority: ctx.accounts.mint.to_account_info(),
         };
-        let cpi_program_id = ctx.accounts.token_program.key();
+        let cpi_program_id = ctx.accounts.token_program.to_account_info();
         let cpi_context = CpiContext::new(cpi_program_id, cpi_accounts).with_signer(signer_seeds);
         // [!code highlight]
         token_interface::mint_to(cpi_context, amount)?;


### PR DESCRIPTION
The example code in mint token is giving out error 

```
error[E0308]: mismatched types
  --> programs/spl-token/src/lib.rs:57:43
   |
57 |         let cpi_context = CpiContext::new(cpi_program_id, cpi_accounts);
   |                           --------------- ^^^^^^^^^^^^^^ expected `AccountInfo<'_>`, found `Pubkey`
   |                           |
   |                           arguments to this function are incorrect
   |
note: associated function defined here
  --> src/context.rs:185:12

For more information about this error, try `rustc --explain E0308`.
```

Fix CPI context creation by using `to_account_info()` instead of `key()`

`CpiContext::new` expects an `AccountInfo`, not a `Pubkey`. Changed `ctx.accounts.token_program.key()` to `ctx.accounts.token_program.to_account_info()`.
