### PR TITLE
Fix cpi_program_id assignment in mint-tokens.mdx

### DIFF
--- a/docs/content/docs/tokens/basics/mint-tokens.mdx
+++ b/docs/content/docs/tokens/basics/mint-tokens.mdx
@@ -71,7 +71,7 @@ pub mod token_example {
             to: ctx.accounts.token_account.to_account_info(),
             authority: ctx.accounts.signer.to_account_info(),
         };
-        let cpi_program_id = ctx.accounts.token_program.key();
+        let cpi_program_id = ctx.accounts.to_account_info();
         let cpi_context = CpiContext::new(cpi_program_id, cpi_accounts);
         token_interface::mint_to(cpi_context, amount)?;
         Ok(())


### PR DESCRIPTION
the CpiContext argument program expects Accounts<'info> whiie  .key() was extracting the Pubkey of the program so replaced it with the .to_acount_info( ) syntax