### PR TITLE
fix: Reduce stack usage in instruction dispatch by boxing bumps and reallocs

### DIFF
--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -183,9 +183,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     let instruction::#variant_arm = ix;
 
                     // Bump collector.
-                    let mut __bumps = <#anchor as anchor_lang::Bumps>::Bumps::default();
+                    let mut __bumps = Box::new(<#anchor as anchor_lang::Bumps>::Bumps::default());
 
-                    let mut __reallocs = std::collections::BTreeSet::new();
+                    let mut __reallocs = Box::new(std::collections::BTreeSet::new());
 
                     // Deserialize accounts.
                     let mut __remaining_accounts: &[AccountInfo] = __accounts;
@@ -193,8 +193,8 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         __program_id,
                         &mut __remaining_accounts,
                         __ix_data,
-                        &mut __bumps,
-                        &mut __reallocs,
+                        &mut *__bumps,
+                        &mut *__reallocs,
                     )?;
 
                     // Invoke user defined handler.
@@ -203,7 +203,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                             __program_id,
                             &mut __accounts,
                             __remaining_accounts,
-                            __bumps,
+                            *__bumps,
                         ),
                         #(#ix_arg_names),*
                     )?;


### PR DESCRIPTION
This PR addresses the "Access Violation in Anchor Validation Phase" (Issue #4114) caused by a stack overflow in the generated instruction dispatcher.

Problem: The #[inline(never)] instruction handler wrapper generated by the #[program] macro was allocating __bumps and __reallocs on the stack. In deep call stacks or specific compilation layouts, this pushed stack usage over the 4KB limit, causing an access violation before the user's function body was even reached.

Fix: Moved __bumps and __reallocs to the heap using Box::new(). This reduces the stack pressure during the critical validation phase (
try_accounts
).

Verification: Verified with a local reproduction case where an instruction (shield_execute) that previously failed with an access violation now succeeds.

