### PR TITLE
feat: Add startup delay to default test script to prevent race conditions

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 const ANCHOR_MSRV: &str = "1.89.0";
+const TEST_SLEEP: &str = "0.3";
 
 /// Program initialization template
 #[derive(Clone, Debug, Default, Eq, PartialEq, Parser, ValueEnum)]
@@ -645,18 +646,18 @@ impl TestTemplate {
         match &self {
             Self::Mocha => {
                 if js {
-                    format!("{pkg_manager_exec_cmd} mocha -t 1000000 tests/")
+                    format!("sleep {TEST_SLEEP} && {pkg_manager_exec_cmd} mocha -t 1000000 tests/")
                 } else {
                     format!(
-                        r#"{pkg_manager_exec_cmd} ts-mocha -p ./tsconfig.json -t 1000000 "tests/**/*.ts""#
+                        r#"sleep {TEST_SLEEP} && {pkg_manager_exec_cmd} ts-mocha -p ./tsconfig.json -t 1000000 "tests/**/*.ts""#
                     )
                 }
             }
             Self::Jest => {
                 if js {
-                    format!("{pkg_manager_exec_cmd} jest")
+                    format!("sleep {TEST_SLEEP} && {pkg_manager_exec_cmd} jest")
                 } else {
-                    format!("{pkg_manager_exec_cmd} jest --preset ts-jest")
+                    format!("sleep {TEST_SLEEP} && {pkg_manager_exec_cmd} jest --preset ts-jest")
                 }
             }
             Self::Rust => "cargo test".to_owned(),


### PR DESCRIPTION
## Problem
The default scaffold from `anchor init` and `anchor new` can experience race conditions where tests run before the solana-test-validator has fully deployed programs, causing "Program is not deployed" errors.

## Solution
This PR adds a 0.3-second sleep delay to the default test script in Anchor.toml. This gives the validator sufficient time to initialize and deploy programs before tests execute.

## Changes
- Modified `cli/src/rust_template.rs` to include `sleep 0.3 &&` prefix in the generated test script
- Applies to both TypeScript (Mocha) and JavaScript (Jest) test templates

## Testing
- Created new projects with `anchor init` and verified the sleep command is present
- Built and tested the CLI locally
- Confirmed the delay prevents race condition errors

## References
- Addresses the issue described in #3624
- Common workaround mentioned in Anchor Discord and Stack Overflow

## Breaking Changes
None - this only affects newly generated projects and improves reliability.