### PR TITLE
Add solana-program-test compatibility test in CI

### DIFF
--- a/.github/workflows/reusable-tests.yaml
+++ b/.github/workflows/reusable-tests.yaml
@@ -480,6 +480,8 @@ jobs:
             path: tests/test-instruction-validation
           - cmd: cd tests/signature-verification && anchor test
             path: tests/signature-verification
+          - cmd: cd tests/solana-program-test-compatibility && cargo test-sbf
+            path: tests/solana-program-test-compatibility
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup/

--- a/tests/package.json
+++ b/tests/package.json
@@ -53,7 +53,8 @@
     "multiple-suites-run-single",
     "bpf-upgradeable-state",
     "duplicate-mutable-accounts",
-    "signature-verification"
+    "signature-verification",
+    "solana-program-test-compatibility"
   ],
   "dependencies": {
     "@project-serum/common": "^0.0.1-beta.3",

--- a/tests/solana-program-test-compatibility/Anchor.toml
+++ b/tests/solana-program-test-compatibility/Anchor.toml
@@ -1,0 +1,16 @@
+[toolchain]
+anchor_version = "0.32.1"
+solana_version = "3.0.0"
+
+[programs.localnet]
+solana_program_test_compatibility = "Cmpatiblt_entrypoint_test_1111111111111111"
+
+[registry]
+url = "https://api.apr.dev"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "cargo test-sbf -- --nocapture"

--- a/tests/solana-program-test-compatibility/Cargo.toml
+++ b/tests/solana-program-test-compatibility/Cargo.toml
@@ -1,0 +1,29 @@
+[workspace]
+members = [
+    "programs/*",
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+[profile.release.package."*"]
+opt-level = 3
+incremental = false
+
+[patch.crates-io]
+# Use local anchor-lang for tests
+anchor-lang = { path = "../../lang" }
+anchor-attribute-access-control = { path = "../../lang/attribute/access-control" }
+anchor-attribute-account = { path = "../../lang/attribute/account" }
+anchor-attribute-constant = { path = "../../lang/attribute/constant" }
+anchor-attribute-error = { path = "../../lang/attribute/error" }
+anchor-attribute-event = { path = "../../lang/attribute/event" }
+anchor-attribute-program = { path = "../../lang/attribute/program" }
+anchor-derive-accounts = { path = "../../lang/derive/accounts" }
+anchor-derive-space = { path = "../../lang/derive/space" }
+anchor-syn = { path = "../../lang/syn" }

--- a/tests/solana-program-test-compatibility/package.json
+++ b/tests/solana-program-test-compatibility/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "solana-program-test-compatibility",
+  "version": "0.32.1",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  },
+  "scripts": {
+    "test": "cargo test-sbf"
+  }
+}

--- a/tests/solana-program-test-compatibility/programs/solana-program-test-compatibility/Cargo.toml
+++ b/tests/solana-program-test-compatibility/programs/solana-program-test-compatibility/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "solana-program-test-compatibility"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "solana_program_test_compatibility"
+
+[features]
+no-entrypoint = []
+no-idl = []
+cpi = ["no-entrypoint"]
+default = []
+test-sbf = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }
+
+[dev-dependencies]
+solana-program-test = "3"
+solana-pubkey = "4"
+tokio = { version = "1", features = ["full"] }

--- a/tests/solana-program-test-compatibility/programs/solana-program-test-compatibility/src/lib.rs
+++ b/tests/solana-program-test-compatibility/programs/solana-program-test-compatibility/src/lib.rs
@@ -1,0 +1,15 @@
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod solana_program_test_compatibility {
+    use super::*;
+
+    pub fn initialize(_ctx: Context<Initialize>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize {}

--- a/tests/solana-program-test-compatibility/tests/compatibility_test.rs
+++ b/tests/solana-program-test-compatibility/tests/compatibility_test.rs
@@ -1,0 +1,14 @@
+use solana_program_test::ProgramTest;
+use solana_pubkey::Pubkey;
+use std::str::FromStr;
+
+#[tokio::test]
+async fn check_entrypoint() {
+    let program_id = Pubkey::from_str("11111111111111111111111111111111").unwrap();
+    let pt = ProgramTest::new(
+        "solana_program_test_compatibility",
+        program_id,
+        None,
+    );
+    let _context = pt.start_with_context().await;
+}


### PR DESCRIPTION
## Summary
This PR adds a CI compatibility test to prevent regressions between `anchor-lang` and `solana-program-test`, addressing issue #2738.

## Changes
- Added a new test suite in `tests/solana-program-test-compatibility/`
- Created a minimal Anchor program that verifies entrypoint compatibility
- Integrated the test into the CI workflow ([.github/workflows/reusable-tests.yaml](cci:7://file:///home/cheryl/.gemini/antigravity/scratch/anchor-contribution/anchor/.github/workflows/reusable-tests.yaml:0:0-0:0))

## Testing
The test creates a simple Anchor program and verifies it can be loaded using `ProgramTest::new()` from the `solana-program-test` crate. This ensures future changes to `anchor-lang` won't break compatibility with standard Solana testing tools.

Tested locally with:
```bash
cd tests/solana-program-test-compatibility
cargo test-sbf