### PR TITLE
fix: correct Lazy size calculation for arrays of unsized types

### DIFF
--- a/lang/src/lazy.rs
+++ b/lang/src/lazy.rs
@@ -68,7 +68,15 @@ impl<T: Lazy, const N: usize> Lazy for [T; N] {
 
     #[inline(always)]
     fn size_of(buf: &[u8]) -> usize {
-        N * T::size_of(buf)
+        if T::SIZED {
+            N * T::size_of(buf)
+        } else {
+            let mut offset = 0;
+            for _ in 0..N {
+                offset += T::size_of(&buf[offset..]);
+            }
+            offset
+        }
     }
 }
 


### PR DESCRIPTION
Fix incorrect size calculation for [T; N] when T is not fixed-size. The previous implementation multiplied the size of the first element by N, which is incorrect for variable-length types. This keeps the fast path for sized types and iterates only when needed