### PR TITLE
feat(lang): expose no-log-ix-name feature flag

### DIFF
--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -13,6 +13,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 allow-missing-optionals = ["anchor-derive-accounts/allow-missing-optionals"]
+no-log-ix-name = []
 anchor-debug = [
     "anchor-attribute-access-control/anchor-debug",
     "anchor-attribute-account/anchor-debug",


### PR DESCRIPTION
The codegen already supports conditional instruction name logging via #[cfg(not(feature = "no-log-ix-name"))], but the feature was never declared in anchor-lang's Cargo.toml, making it inaccessible to users.

This exposes the feature so programs can disable instruction name logging by adding features = ["no-log-ix-name"] to their anchor-lang dependency.