### PR TITLE
Security Fix: Zero discriminator on close to prevent account revival

### DIFF
--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -4,6 +4,18 @@ use crate::solana_program::system_program;
 use crate::Result;
 
 pub fn close<'info>(info: AccountInfo<'info>, sol_destination: AccountInfo<'info>) -> Result<()> {
+    // Zero out the account discriminator to prevent revival via init_if_needed.
+    // Even if the account hasn't been garbage collected yet, the zeroed
+    // discriminator ensures Anchor's deserialization will reject it.
+    {
+        let mut data = info.try_borrow_mut_data()?;
+        // Zero the first 8 bytes (Anchor discriminator)
+        let len = std::cmp::min(data.len(), 8);
+        for byte in data[..len].iter_mut() {
+            *byte = 0;
+        }
+    }
+
     // Transfer tokens from the account to the sol_destination.
     let dest_starting_lamports = sol_destination.lamports();
     **sol_destination.lamports.borrow_mut() =


### PR DESCRIPTION
## Security Finding

### [HIGH] Account Close Revival Attack
**File:** `lang/src/common.rs` — `close()` function

**Issue:**
The `close()` function transfers lamports, assigns ownership to System program, and resizes to 0. However, the `is_closed()` check (`owner == System::id() && data_is_empty()`) may not detect a closed account within the same transaction before the runtime processes the ownership change.

**Attack Scenario:**
1. Program instruction A closes an account using `close()`
2. Program instruction B (same transaction) uses `init_if_needed` on the same account
3. If the runtime hasn't garbage-collected yet, the account can be re-initialized
4. The attacker now has a 'fresh' account that reuses the same PDA, potentially resetting important state

**Fix:** Zero the first 8 bytes (Anchor discriminator) **before** transferring lamports. Even if the account data persists temporarily in the runtime, Anchor's deserialization will reject it with `AccountDiscriminatorMismatch`, preventing any `init_if_needed` from succeeding.

**Impact:** Affects all programs using `close()` + `init_if_needed` on the same account type.

---
*Found during a Solana security audit*