### PR TITLE
fix(lang): Include system program AccountInfo in CPI invoke calls

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -36,6 +36,7 @@
     "relations-derivation",
     "pyth",
     "realloc",
+    "realloc-cpi-bug",
     "spl/metadata",
     "spl/token-extensions",
     "spl/token-proxy",

--- a/tests/realloc-cpi-bug/Anchor.toml
+++ b/tests/realloc-cpi-bug/Anchor.toml
@@ -1,0 +1,13 @@
+[features]
+seeds = false
+
+[programs.localnet]
+callee = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+caller = "HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[scripts]
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"

--- a/tests/realloc-cpi-bug/Cargo.toml
+++ b/tests/realloc-cpi-bug/Cargo.toml
@@ -1,0 +1,8 @@
+[workspace]
+members = [
+    "programs/*"
+]
+resolver = "2"
+
+[profile.release]
+overflow-checks = true

--- a/tests/realloc-cpi-bug/package.json
+++ b/tests/realloc-cpi-bug/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "realloc-cpi-bug",
+  "version": "0.32.1",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=17"
+  },
+  "scripts": {
+    "test": "anchor test"
+  }
+}

--- a/tests/realloc-cpi-bug/programs/callee/Cargo.toml
+++ b/tests/realloc-cpi-bug/programs/callee/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "callee"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "callee"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }

--- a/tests/realloc-cpi-bug/programs/callee/Xargo.toml
+++ b/tests/realloc-cpi-bug/programs/callee/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/realloc-cpi-bug/programs/callee/src/lib.rs
+++ b/tests/realloc-cpi-bug/programs/callee/src/lib.rs
@@ -1,0 +1,70 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod callee {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        ctx.accounts.data_account.data = vec![0];
+        ctx.accounts.data_account.bump = ctx.bumps.data_account;
+        Ok(())
+    }
+
+    pub fn realloc(ctx: Context<Realloc>, len: u16) -> Result<()> {
+        ctx.accounts
+            .data_account
+            .data
+            .resize_with(len as usize, Default::default);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        init,
+        payer = authority,
+        seeds = [b"data"],
+        bump,
+        space = DataAccount::space(1),
+    )]
+    pub data_account: Account<'info, DataAccount>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+#[instruction(len: u16)]
+pub struct Realloc<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"data"],
+        bump = data_account.bump,
+        realloc = DataAccount::space(len as usize),
+        realloc::payer = authority,
+        realloc::zero = false,
+    )]
+    pub data_account: Account<'info, DataAccount>,
+
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct DataAccount {
+    pub data: Vec<u8>,
+    pub bump: u8,
+}
+
+impl DataAccount {
+    pub fn space(len: usize) -> usize {
+        8 + (4 + len) + 1
+    }
+}

--- a/tests/realloc-cpi-bug/programs/caller/Cargo.toml
+++ b/tests/realloc-cpi-bug/programs/caller/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "caller"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "caller"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+idl-build = ["anchor-lang/idl-build"]
+
+[dependencies]
+anchor-lang = { path = "../../../../lang" }
+callee = { path = "../callee", features = ["cpi"] }

--- a/tests/realloc-cpi-bug/programs/caller/Xargo.toml
+++ b/tests/realloc-cpi-bug/programs/caller/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/tests/realloc-cpi-bug/programs/caller/src/lib.rs
+++ b/tests/realloc-cpi-bug/programs/caller/src/lib.rs
@@ -1,0 +1,34 @@
+use anchor_lang::prelude::*;
+use callee::cpi::accounts::Realloc;
+use callee::program::Callee;
+
+declare_id!("HmbTLCmaGvZhKnn1Zfa1JVnp7vkMV4DYVxPLWBVoN65L");
+
+#[program]
+pub mod caller {
+    use super::*;
+
+    pub fn call_realloc(ctx: Context<CallRealloc>, len: u16) -> Result<()> {
+        let cpi_program = ctx.accounts.callee_program.key();
+        let cpi_accounts = Realloc {
+            authority: ctx.accounts.authority.to_account_info(),
+            data_account: ctx.accounts.data_account.to_account_info(),
+            system_program: ctx.accounts.system_program.to_account_info(),
+        };
+        let cpi_ctx = CpiContext::new(cpi_program, cpi_accounts);
+        callee::cpi::realloc(cpi_ctx, len)
+    }
+}
+
+#[derive(Accounts)]
+pub struct CallRealloc<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    /// CHECK: Validated by callee program
+    #[account(mut)]
+    pub data_account: UncheckedAccount<'info>,
+
+    pub callee_program: Program<'info, Callee>,
+    pub system_program: Program<'info, System>,
+}

--- a/tests/realloc-cpi-bug/tests/realloc-cpi-bug.ts
+++ b/tests/realloc-cpi-bug/tests/realloc-cpi-bug.ts
@@ -1,0 +1,103 @@
+import assert from "assert";
+import * as anchor from "@anchor-lang/core";
+import { Program } from "@anchor-lang/core";
+import { Callee } from "../target/types/callee";
+import { Caller } from "../target/types/caller";
+
+const { SystemProgram } = anchor.web3;
+
+describe("realloc-cpi-bug", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const calleeProgram = anchor.workspace.Callee as Program<Callee>;
+  const callerProgram = anchor.workspace.Caller as Program<Caller>;
+
+  let dataAccount: anchor.web3.PublicKey;
+
+  before(async () => {
+    [dataAccount] = anchor.web3.PublicKey.findProgramAddressSync(
+      [Buffer.from("data")],
+      calleeProgram.programId
+    );
+  });
+
+  it("initializes the data account", async () => {
+    await calleeProgram.methods
+      .initialize()
+      .accounts({
+        authority: provider.wallet.publicKey,
+        dataAccount,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+
+    const account = await calleeProgram.account.dataAccount.fetch(dataAccount);
+    assert.strictEqual(account.data.length, 1);
+  });
+
+  it("can realloc via direct call", async () => {
+    await calleeProgram.methods
+      .realloc(100)
+      .accounts({
+        authority: provider.wallet.publicKey,
+        dataAccount,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+
+    const account = await calleeProgram.account.dataAccount.fetch(dataAccount);
+    assert.strictEqual(account.data.length, 100);
+  });
+
+  it("can realloc via CPI (caller -> callee)", async () => {
+    // This is the key test case: CPI depth 2 realloc.
+    // Before the fix, this would fail with:
+    // "sum of account balances before and after instruction do not match"
+    await callerProgram.methods
+      .callRealloc(200)
+      .accounts({
+        authority: provider.wallet.publicKey,
+        dataAccount,
+        calleeProgram: calleeProgram.programId,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+
+    const account = await calleeProgram.account.dataAccount.fetch(dataAccount);
+    assert.strictEqual(account.data.length, 200);
+  });
+
+  it("can realloc to smaller size via CPI", async () => {
+    // Test shrinking also works via CPI (this doesn't use system_program::transfer,
+    // but verifies the realloc path doesn't break).
+    await callerProgram.methods
+      .callRealloc(50)
+      .accounts({
+        authority: provider.wallet.publicKey,
+        dataAccount,
+        calleeProgram: calleeProgram.programId,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+
+    const account = await calleeProgram.account.dataAccount.fetch(dataAccount);
+    assert.strictEqual(account.data.length, 50);
+  });
+
+  it("can realloc back to larger size via CPI", async () => {
+    // Grow again after shrinking, to verify the transfer path works at CPI depth 2.
+    await callerProgram.methods
+      .callRealloc(500)
+      .accounts({
+        authority: provider.wallet.publicKey,
+        dataAccount,
+        calleeProgram: calleeProgram.programId,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+
+    const account = await calleeProgram.account.dataAccount.fetch(dataAccount);
+    assert.strictEqual(account.data.length, 500);
+  });
+});

--- a/tests/realloc-cpi-bug/tsconfig.json
+++ b/tests/realloc-cpi-bug/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai"],
+    "lib": ["es2015"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #4132

- **Root cause**: Anchor's codegen for `realloc` and `init` constraints used system program wrapper functions (`transfer`, `create_account`, `allocate`, `assign`) that called `invoke_signed` without including the system program's `AccountInfo`. This works at CPI depth 1 (runtime resolves from transaction accounts) but fails at depth 2+ with `"sum of account balances before and after instruction do not match"`.

- **Fix**: Replace all wrapper calls in `constraints.rs` and `idl.rs` with direct `invoke`/`invoke_signed` that include `system_program.to_account_info()` in the account infos array. Uses `invoke` (not `invoke_signed`) for transfer operations where the payer is already a `Signer`, avoiding unnecessary signer seed lookups. This also eliminates heap allocations from `CpiContext`/struct construction.

- **Files changed**:
  - `lang/syn/src/codegen/accounts/constraints.rs` — Fixed `generate_constraint_realloc()` and `generate_create_account()` (covers `realloc`, `init`, `init_if_needed` for all account types)
  - `lang/syn/src/codegen/program/idl.rs` — Fixed `__idl_resize_account`
  - `tests/realloc-cpi-bug/` — New reproduction test with caller/callee CPI pattern

## Test plan

- [x] New `tests/realloc-cpi-bug/` — 5/5 passing (direct realloc, CPI realloc grow, CPI shrink, CPI grow-after-shrink)
- [x] Existing `tests/realloc/` — 5/5 passing (no regressions)
- [x] Existing `tests/cpi-returns/` — 11/11 passing (verifies `init` codegen path)
- [x] `cargo test -p anchor-syn` — passes