### PR TITLE
fix(cli): add edition and rust-version to workspace manifest template

### DIFF
--- a/cli/src/rust_template.rs
+++ b/cli/src/rust_template.rs
@@ -171,12 +171,17 @@ pub fn handler(ctx: Context<Initialize>) -> Result<()> {
     ]
 }
 
-const fn workspace_manifest() -> &'static str {
-    r#"[workspace]
+fn workspace_manifest() -> String {
+    format!(
+        r#"[workspace]
 members = [
     "programs/*"
 ]
 resolver = "2"
+
+[workspace.package]
+edition = "2021"
+rust-version = "{ANCHOR_MSRV}"
 
 [profile.release]
 overflow-checks = true
@@ -187,6 +192,7 @@ opt-level = 3
 incremental = false
 codegen-units = 1
 "#
+    )
 }
 
 fn cargo_toml(name: &str, with_mollusk: bool) -> String {
@@ -205,7 +211,8 @@ mollusk-svm = "~0.4"
 name = "{0}"
 version = "0.1.0"
 description = "Created with Anchor"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
## Summary

Fixes #4047 — `anchor init` generates a workspace `Cargo.toml` missing `edition` and `rust-version`, which can cause build failures when Cargo resolves edition2024-only dependency versions.

## Problem

The workspace `Cargo.toml` template had no `edition` or `rust-version` keys. While individual program crates set `edition = "2021"`, Cargo's MSRV-aware dependency resolver uses **workspace-level** settings. Without them, crates requiring Rust edition 2024 (e.g. `base64ct@1.8.0`) could be resolved, breaking builds with:

```
error: package `base64ct v1.8.0` cannot be built because it requires rustc 1.85 or newer
```

## Fix

- Add `[workspace.package]` section with `edition = "2021"` and `rust-version` set to `ANCHOR_MSRV` (currently `1.89.0`)
- Update program `Cargo.toml` template to inherit these via `edition.workspace = true` and `rust-version.workspace = true`

This ensures Cargo's resolver respects the MSRV constraint at the workspace level, preventing incompatible crate versions from being resolved.