### PR TITLE
lang: replace unwrap() with graceful error in close()

### DIFF
--- a/lang/src/common.rs
+++ b/lang/src/common.rs
@@ -1,13 +1,14 @@
 use crate::prelude::{Id, System};
 use crate::solana_program::account_info::AccountInfo;
 use crate::solana_program::system_program;
-use crate::Result;
+use crate::{error::ErrorCode, Result};
 
 pub fn close<'info>(info: AccountInfo<'info>, sol_destination: AccountInfo<'info>) -> Result<()> {
     // Transfer tokens from the account to the sol_destination.
     let dest_starting_lamports = sol_destination.lamports();
-    **sol_destination.lamports.borrow_mut() =
-        dest_starting_lamports.checked_add(info.lamports()).unwrap();
+    **sol_destination.lamports.borrow_mut() = dest_starting_lamports
+        .checked_add(info.lamports())
+        .ok_or(ErrorCode::InvalidNumericConversion)?;
     **info.lamports.borrow_mut() = 0;
 
     info.assign(&system_program::ID);


### PR DESCRIPTION
## Summary
Closes #4224

### Problem
The `close()` function in `anchor-lang/src/common.rs` uses `unwrap()` on a `checked_add` when transferring lamports:

```rust
dest_starting_lamports.checked_add(info.lamports()).unwrap();
```

While a lamport overflow is extremely unlikely in practice (would require > `u64::MAX` lamports), using `unwrap()` in on-chain code is problematic:
- A panic consumes the entire transaction's compute budget
- No meaningful error is returned to the caller
- It goes against Anchor's convention of graceful error handling

### Solution
Replace `unwrap()` with `.ok_or(ErrorCode::InvalidNumericConversion)?`:

```rust
dest_starting_lamports
    .checked_add(info.lamports())
    .ok_or(ErrorCode::InvalidNumericConversion)?;
```

This returns a proper Anchor error code instead of panicking, consistent with the error handling patterns used elsewhere in the codebase.